### PR TITLE
Add simple formatting for state in partial game strategy

### DIFF
--- a/atl-checker/src/algorithms/game_strategy/format.rs
+++ b/atl-checker/src/algorithms/game_strategy/format.rs
@@ -23,7 +23,12 @@ impl<'a, G: GameStructure> Display for PartialStrategyWithFormatting<'a, G> {
                 .to_string()
         )?;
         for (state, pmove) in &self.strategy.move_to_pick {
-            writeln!(f, "{}: {}", state, pmove.in_context_of(self.game, state))?;
+            writeln!(
+                f,
+                "{}: {}",
+                self.game.state_name(*state),
+                pmove.in_context_of(self.game, state)
+            )?;
         }
         Ok(())
     }


### PR DESCRIPTION
A partial game strategy now looks like this:
```
Partial strategy for the player(s): p0, p1
{p0.health:0,p2.health:1,p1.health:2}: p0.wait, p1.shoot_right
{p1.health:1,p0.health:1,p2.health:0}: p0.wait, p1.wait
{p1.health:2,p2.health:2,p0.health:2}: p0.wait, p1.wait
{p2.health:0,p0.health:0,p1.health:2}: p0.wait, p1.wait
{p0.health:1,p1.health:0,p2.health:0}: p0.wait, p1.wait
{p1.health:0,p0.health:2,p2.health:1}: p0.shoot_left, p1.wait
{p1.health:2,p2.health:1,p0.health:1}: p0.wait, p1.wait
{p2.health:1,p1.health:1,p0.health:1}: p0.shoot_left, p1.wait
{p2.health:2,p0.health:1,p1.health:2}: p0.shoot_left, p1.wait
{p0.health:2,p1.health:1,p2.health:2}: p0.shoot_left, p1.wait
{p0.health:2,p2.health:1,p1.health:1}: p0.wait, p1.wait
{p2.health:0,p1.health:1,p0.health:0}: p0.wait, p1.wait
{p2.health:0,p1.health:0,p0.health:2}: p0.wait, p1.wait

```