### PR TITLE
Add new, short suite for quick CI turnaround

### DIFF
--- a/benches/benchmark_solver.rs
+++ b/benches/benchmark_solver.rs
@@ -2547,13 +2547,16 @@ criterion_group!(
     rand_5p_5m_3000d_state_enforce_until_1,
     rand_5p_5m_3000d_state_enforce_until_2,
 );
+// tiny suite for shorter github CI turnaround, check still fails if any path in any declared bench is wrong
+criterion_group!(github_action_suite, mexican_standoff_3p_3hp_lcgs_survive);
 
 criterion_main!(
-    static_thread_case_studies,
-    rand_1p_1m_530d,
-    rand_2p_1m_546d,
-    rand_3p_1m_400d,
-    rand_3p_3m_405d,
-    rand_3p_4m_171d,
-    //rand_4p_4m_3000d //disable large test which results in no-space error on MCC
+    github_action_suite, // remember to disable when benchmarking
+                         //static_thread_case_studies,
+                         //rand_1p_1m_530d,
+                         //rand_2p_1m_546d,
+                         //rand_3p_1m_400d,
+                         //rand_3p_3m_405d,
+                         //rand_3p_4m_171d,
+                         //rand_4p_4m_3000d //disable large test which results in no-space error on MCC
 ); // choose which group(s) to bench


### PR DESCRIPTION
Does what it says on the tin :tm: 

If paths of any declared bench is wrong, the `cargo test --benches` flow fails, but we don't waste time on running each bench once for every CI check.

In future for real benchmarks, the user has to disable this suite - but it's described in comment directly at criterion_main function call.