### PR TITLE
[clean] Clean tests and fix worker crashes

### DIFF
--- a/atl-checker/Cargo.toml
+++ b/atl-checker/Cargo.toml
@@ -19,7 +19,7 @@ graph-printer = []
 use-counts = []
 
 [dev-dependencies]
-test-env-log = { version = "0.2.5", features = ["trace"], default-features = false }
+test-log = { version = "0.2.11", features = ["trace"], default-features = false }
 criterion = "0.3"
 tracing-subscriber = "0.2.17"
 serde_json = "1.0.59"

--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -85,6 +85,12 @@ pub fn distributed_certain_zero<
 
         CertainZeroResult::AllFoundAssignments(combined)
     } else {
+        // Receive (but discard) all assignments, such that the workers can terminate correctly
+        for _ in 0..worker_count {
+            let _ = manager_broker
+                .receive_assignment()
+                .expect("Error receiving the assignment table");
+        }
         CertainZeroResult::RootAssignment(root_assignment)
     }
 }
@@ -254,6 +260,9 @@ impl<
         while self.running {
             // Receive incoming tasks and terminate if requested
             self.recv_all_and_fill_queues();
+            if !self.running {
+                break;
+            }
 
             if self.process_task() {
                 continue; // We did a task

--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -855,7 +855,7 @@ mod test {
     /// edg_assert!([MyEDG1, MyVertex1] B, FALSE);
     /// ```
     #[allow(unused_macros)]
-    macro_rules! edg_assert {
+    macro_rules! assert_with_otf_algo {
         // Standard use, no names or worker count given
         ( $v:ident, $assign:ident ) => {
             edg_assert!([SimpleEDG, SimpleVertex] $v, $assign, 3)
@@ -886,7 +886,7 @@ mod test {
         simple_edg![
             A => -> {};
         ];
-        edg_assert!(A, True);
+        assert_with_otf_algo!(A, True);
     }
 
     #[test]
@@ -894,7 +894,7 @@ mod test {
         simple_edg![
             A => ;
         ];
-        edg_assert!(A, False);
+        assert_with_otf_algo!(A, False);
     }
 
     #[test]
@@ -905,10 +905,10 @@ mod test {
             C => .> D;
             D => -> {};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, False);
-        edg_assert!(C, False);
-        edg_assert!(D, True);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, False);
+        assert_with_otf_algo!(D, True);
     }
 
     #[test]
@@ -920,11 +920,11 @@ mod test {
             D => -> {} -> {C};
             E => .> D;
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, True);
-        edg_assert!(C, True);
-        edg_assert!(D, True);
-        edg_assert!(E, False);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, True);
+        assert_with_otf_algo!(E, False);
     }
 
     #[test]
@@ -940,15 +940,15 @@ mod test {
             H => -> {I};
             I => ;
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, True);
-        edg_assert!(C, True);
-        edg_assert!(D, True);
-        edg_assert!(E, True);
-        edg_assert!(F, True);
-        edg_assert!(G, False);
-        edg_assert!(H, False);
-        edg_assert!(I, False);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, True);
+        assert_with_otf_algo!(E, True);
+        assert_with_otf_algo!(F, True);
+        assert_with_otf_algo!(G, False);
+        assert_with_otf_algo!(H, False);
+        assert_with_otf_algo!(I, False);
     }
 
     #[test]
@@ -959,10 +959,10 @@ mod test {
             C => ;
             D => -> {};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, True);
-        edg_assert!(C, False);
-        edg_assert!(D, True);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, False);
+        assert_with_otf_algo!(D, True);
     }
 
     #[test]
@@ -972,9 +972,9 @@ mod test {
             B => -> {C};
             C => -> {B};
         ];
-        edg_assert!(A, False);
-        edg_assert!(B, False);
-        edg_assert!(C, False);
+        assert_with_otf_algo!(A, False);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, False);
     }
 
     #[test]
@@ -984,9 +984,9 @@ mod test {
             B => ;
             C => ;
         ];
-        edg_assert!(A, False);
-        edg_assert!(B, False);
-        edg_assert!(C, False);
+        assert_with_otf_algo!(A, False);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, False);
     }
 
     #[test]
@@ -997,10 +997,10 @@ mod test {
             C => -> {D};
             D => -> {};
         ];
-        edg_assert!(A, False);
-        edg_assert!(B, False);
-        edg_assert!(C, True);
-        edg_assert!(D, True);
+        assert_with_otf_algo!(A, False);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, True);
     }
 
     #[test]
@@ -1011,10 +1011,10 @@ mod test {
             C => -> {B};
             D => -> {C} -> {};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, True);
-        edg_assert!(C, True);
-        edg_assert!(D, True);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, True);
     }
 
     #[test]
@@ -1023,8 +1023,8 @@ mod test {
             A => .> B;
             B => -> {};
         ];
-        edg_assert!(A, False);
-        edg_assert!(B, True);
+        assert_with_otf_algo!(A, False);
+        assert_with_otf_algo!(B, True);
     }
 
     #[test]
@@ -1036,11 +1036,11 @@ mod test {
             D => -> {E};
             E => -> {D};
         ];
-        edg_assert!(A, False);
-        edg_assert!(B, True);
-        edg_assert!(C, True);
-        edg_assert!(D, False);
-        edg_assert!(E, False);
+        assert_with_otf_algo!(A, False);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, False);
+        assert_with_otf_algo!(E, False);
     }
 
     #[test]
@@ -1051,10 +1051,10 @@ mod test {
             C => -> {D};
             D => ;
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, True);
-        edg_assert!(C, False);
-        edg_assert!(D, False);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, True);
+        assert_with_otf_algo!(C, False);
+        assert_with_otf_algo!(D, False);
     }
 
     #[test]
@@ -1063,8 +1063,8 @@ mod test {
             A => .> B;
             B => -> {B};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, False);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, False);
     }
 
     #[test]
@@ -1077,12 +1077,12 @@ mod test {
             E => .> F;
             F => -> {F};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, False);
-        edg_assert!(C, True);
-        edg_assert!(D, False);
-        edg_assert!(E, True);
-        edg_assert!(F, False);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, True);
+        assert_with_otf_algo!(D, False);
+        assert_with_otf_algo!(E, True);
+        assert_with_otf_algo!(F, False);
     }
 
     #[test]
@@ -1102,12 +1102,12 @@ mod test {
             J => -> {K};
             K => -> {};
         ];
-        edg_assert!(A, True);
-        edg_assert!(B, False);
-        edg_assert!(C, False);
-        edg_assert!(D, False);
-        edg_assert!(E, True);
-        edg_assert!(F, True);
-        edg_assert!(G, True);
+        assert_with_otf_algo!(A, True);
+        assert_with_otf_algo!(B, False);
+        assert_with_otf_algo!(C, False);
+        assert_with_otf_algo!(D, False);
+        assert_with_otf_algo!(E, True);
+        assert_with_otf_algo!(F, True);
+        assert_with_otf_algo!(G, True);
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -808,7 +808,7 @@ impl<
 
 #[cfg(test)]
 mod test {
-    use test_env_log::test;
+    use test_log::test;
 
     /// Defines an assertion which test the assignment of a vertex in an EDG using the
     /// distributed certain zero algorithm.
@@ -822,8 +822,8 @@ mod test {
     ///     B => -> {};
     /// ];
     ///
-    /// edg_assert!(A, FALSE);
-    /// edg_assert!(B, TRUE);
+    /// assert_with_otf_algo!(A, FALSE);
+    /// assert_with_otf_algo!(B, TRUE);
     /// ```
     /// Note that TRUE/FALSE must be capitalized.
     ///
@@ -831,7 +831,7 @@ mod test {
     /// You can set the worker count by supplying a third argument to the marco. The default
     /// number of workers are 3.
     /// ```
-    /// edg_assert!(A, FALSE, 5);
+    /// assert_with_otf_algo!(A, FALSE, 5);
     /// ```
     ///
     /// # Custom names
@@ -851,22 +851,22 @@ mod test {
     ///     D => -> {C};
     /// ];
     ///
-    /// edg_assert!([MyEDG1, MyVertex1] A, TRUE);
-    /// edg_assert!([MyEDG1, MyVertex1] B, FALSE);
+    /// assert_with_otf_algo!([MyEDG1, MyVertex1] A, TRUE);
+    /// assert_with_otf_algo!([MyEDG1, MyVertex1] B, FALSE);
     /// ```
     #[allow(unused_macros)]
     macro_rules! assert_with_otf_algo {
         // Standard use, no names or worker count given
         ( $v:ident, $assign:ident ) => {
-            edg_assert!([SimpleEDG, SimpleVertex] $v, $assign, 3)
+            assert_with_otf_algo!([SimpleEDG, SimpleVertex] $v, $assign, 3)
         };
         // With worker count given
         ( $v:ident, $assign:ident, $wc:expr ) => {
-            edg_assert!([SimpleEDG, SimpleVertex] $v, $assign, $wc)
+            assert_with_otf_algo!([SimpleEDG, SimpleVertex] $v, $assign, $wc)
         };
         // With custom names given
         ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:ident ) => {
-            edg_assert!([$edg_name, $vertex_name] $v, $assign, 3)
+            assert_with_otf_algo!([$edg_name, $vertex_name] $v, $assign, 3)
         };
         // With custom names and worker count
         ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:ident, $wc:expr ) => {

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -171,12 +171,13 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
 }
 #[cfg(test)]
 mod test {
-    use test_env_log::test;
+    use test_log::test;
+
     #[allow(unused_macros)]
     macro_rules! assert_with_global {
         // Standard use, no names or worker count given
         ( $v:ident, $assign:expr ) => {
-            edg_assert!([SimpleEDG, SimpleVertex] $v, $assign)
+            assert_with_global!([SimpleEDG, SimpleVertex] $v, $assign)
         };
         // With custom names and worker count
         ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:expr) => {

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -173,7 +173,7 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
 mod test {
     use test_env_log::test;
     #[allow(unused_macros)]
-    macro_rules! edg_assert {
+    macro_rules! assert_with_global {
         // Standard use, no names or worker count given
         ( $v:ident, $assign:expr ) => {
             edg_assert!([SimpleEDG, SimpleVertex] $v, $assign)
@@ -194,7 +194,7 @@ mod test {
         simple_edg![
             A => -> {};
         ];
-        edg_assert!(A, true);
+        assert_with_global!(A, true);
     }
 
     #[test]
@@ -202,7 +202,7 @@ mod test {
         simple_edg![
             A => ;
         ];
-        edg_assert!(A, false);
+        assert_with_global!(A, false);
     }
 
     #[test]
@@ -213,10 +213,10 @@ mod test {
             C => .> D;
             D => -> {};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-        edg_assert!(D, true);
+        assert_with_global!(A, true);
+        assert_with_global!(B, false);
+        assert_with_global!(C, false);
+        assert_with_global!(D, true);
     }
 
     #[test]
@@ -228,11 +228,11 @@ mod test {
             D => -> {} -> {C};
             E => .> D;
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-        edg_assert!(E, false);
+        assert_with_global!(A, true);
+        assert_with_global!(B, true);
+        assert_with_global!(C, true);
+        assert_with_global!(D, true);
+        assert_with_global!(E, false);
     }
 
     #[test]
@@ -248,15 +248,15 @@ mod test {
             H => -> {I};
             I => ;
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-        edg_assert!(E, true);
-        edg_assert!(F, true);
-        edg_assert!(G, false);
-        edg_assert!(H, false);
-        edg_assert!(I, false);
+        assert_with_global!(A, true);
+        assert_with_global!(B, true);
+        assert_with_global!(C, true);
+        assert_with_global!(D, true);
+        assert_with_global!(E, true);
+        assert_with_global!(F, true);
+        assert_with_global!(G, false);
+        assert_with_global!(H, false);
+        assert_with_global!(I, false);
     }
 
     #[test]
@@ -267,10 +267,10 @@ mod test {
             C => ;
             D => -> {};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, false);
-        edg_assert!(D, true);
+        assert_with_global!(A, true);
+        assert_with_global!(B, true);
+        assert_with_global!(C, false);
+        assert_with_global!(D, true);
     }
 
     #[test]
@@ -280,9 +280,9 @@ mod test {
             B => -> {C};
             C => -> {B};
         ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
+        assert_with_global!(A, false);
+        assert_with_global!(B, false);
+        assert_with_global!(C, false);
     }
 
     #[test]
@@ -292,9 +292,9 @@ mod test {
             B => ;
             C => ;
         ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
+        assert_with_global!(A, false);
+        assert_with_global!(B, false);
+        assert_with_global!(C, false);
     }
 
     #[test]
@@ -305,10 +305,10 @@ mod test {
             C => -> {D};
             D => -> {};
         ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
+        assert_with_global!(A, false);
+        assert_with_global!(B, false);
+        assert_with_global!(C, true);
+        assert_with_global!(D, true);
     }
 
     #[test]
@@ -319,10 +319,10 @@ mod test {
             C => -> {B};
             D => -> {C} -> {};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
+        assert_with_global!(A, true);
+        assert_with_global!(B, true);
+        assert_with_global!(C, true);
+        assert_with_global!(D, true);
     }
 
     #[test]
@@ -331,8 +331,8 @@ mod test {
             A => .> B;
             B => -> {};
         ];
-        edg_assert!(A, false);
-        edg_assert!(B, true);
+        assert_with_global!(A, false);
+        assert_with_global!(B, true);
     }
 
     #[test]
@@ -344,11 +344,11 @@ mod test {
             D => -> {E};
             E => -> {D};
         ];
-        edg_assert!(A, false);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, false);
-        edg_assert!(E, false);
+        assert_with_global!(A, false);
+        assert_with_global!(B, true);
+        assert_with_global!(C, true);
+        assert_with_global!(D, false);
+        assert_with_global!(E, false);
     }
 
     #[test]
@@ -359,10 +359,10 @@ mod test {
             C => -> {D};
             D => ;
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, false);
-        edg_assert!(D, false);
+        assert_with_global!(A, true);
+        assert_with_global!(B, true);
+        assert_with_global!(C, false);
+        assert_with_global!(D, false);
     }
 
     #[test]
@@ -371,8 +371,8 @@ mod test {
             A => .> B;
             B => -> {B};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
+        assert_with_global!(A, true);
+        assert_with_global!(B, false);
     }
 
     #[test]
@@ -385,12 +385,12 @@ mod test {
             E => .> F;
             F => -> {F};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, true);
-        edg_assert!(D, false);
-        edg_assert!(E, true);
-        edg_assert!(F, false);
+        assert_with_global!(A, true);
+        assert_with_global!(B, false);
+        assert_with_global!(C, true);
+        assert_with_global!(D, false);
+        assert_with_global!(E, true);
+        assert_with_global!(F, false);
     }
 
     #[test]
@@ -410,12 +410,12 @@ mod test {
             J => -> {K};
             K => -> {};
         ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-        edg_assert!(D, false);
-        edg_assert!(E, true);
-        edg_assert!(F, true);
-        edg_assert!(G, true);
+        assert_with_global!(A, true);
+        assert_with_global!(B, false);
+        assert_with_global!(C, false);
+        assert_with_global!(D, false);
+        assert_with_global!(E, true);
+        assert_with_global!(F, true);
+        assert_with_global!(G, true);
     }
 }

--- a/atl-checker/src/game_structure/lcgs/parse.rs
+++ b/atl-checker/src/game_structure/lcgs/parse.rs
@@ -1113,7 +1113,6 @@ mod tests {
         // Test range with only negative number
         let input = br"[-20..-1]";
         let parser = type_range();
-        println!("{:?}", parser.parse(input));
         assert_eq!(
             parser.parse(input),
             Ok(TypeRange {
@@ -1307,7 +1306,6 @@ mod tests {
 
         endtemplate"#;
         let parser = template_decl();
-        println!("{:?}", parser.parse(input));
         assert!(parser.parse(input).is_ok());
     }
 
@@ -1332,7 +1330,6 @@ mod tests {
         endtemplate
         "#;
         let parser = root();
-        println!("{:?}", parser.parse(input));
         assert!(parser.parse(input).is_ok());
     }
 

--- a/atl-checker/src/simple_edg.rs
+++ b/atl-checker/src/simple_edg.rs
@@ -1,6 +1,5 @@
 /// Defines a hardcoded EDG.
-/// This allows us to easily create EDGs for testing and other purposes. It works well
-/// together with the `edg_assert` macro.
+/// This allows us to easily create EDGs for testing and other purposes.
 ///
 /// # Example A
 /// A simple EDG with 4 vertices A, B, C, D:
@@ -11,9 +10,6 @@
 ///     C => -> {B} .> D;
 ///     D => -> {};
 /// ];
-///
-/// edg_assert!(A, TRUE);
-/// edg_assert!(B, FALSE);
 /// ```
 /// We list the edges of each vertex, separating each vertex using a semicolon.
 /// The syntax `-> {V, ..., W}` defines a hyper-edge with targets `V`,...,`W`, and the syntax
@@ -36,11 +32,7 @@
 ///     C => ;
 ///     D => -> {C};
 /// ];
-///
-/// edg_assert!([MyEDG1, MyVertex1] A, TRUE);
-/// edg_assert!([MyEDG1, MyVertex1] B, FALSE);
 /// ```
-/// The `edg_assert` macro allows the same naming functionality.
 #[allow(unused_macros)]
 macro_rules! simple_edg {
     // Standard use


### PR DESCRIPTION
- Fix `test_env_log::test` deprecation by changing to `test_log::test`.
- Rename some macros and delete them from doc example, where they are not in scope.
- Make workers terminate correctly without crashes