### PR TITLE
Support for multiple threads using the global algorithm

### DIFF
--- a/atl-checker/src/algorithms/global/com.rs
+++ b/atl-checker/src/algorithms/global/com.rs
@@ -1,0 +1,139 @@
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::hash::Hash;
+use crossbeam_channel::{Receiver, Sender, TryRecvError};
+
+#[derive(Clone, Debug)]
+pub enum GMessage<V: Hash + Eq + PartialEq + Clone> {
+    Assignment {
+        assignment: HashMap<V,bool>,
+    },
+    Terminate,
+}
+
+pub trait GBroker<V: Hash + Eq + PartialEq + Clone> {
+
+    fn return_changes(&self, assignments: HashSet<(V, bool)>);
+
+    fn receive(&self) -> Result<Option<GMessage<V>>, Box<dyn Error>>;
+
+    fn get_task(&self) -> Result<Option<V>, Box<dyn Error>>;
+}
+
+pub trait GBrokerManager<V: Hash + Eq + PartialEq + Clone> {
+    fn send_assignments(&self, assignments: HashMap<V,bool>);
+    fn queue_task(&self, task: V);
+    fn receive_changes(&self) -> Result<HashSet<(V, bool)>, Box<dyn Error>>;
+    fn terminate(&self);
+
+}
+
+pub struct GChannelBrokerManager<V: Hash + Eq + PartialEq + Clone> {
+    workers: Vec<Sender<GMessage<V>>>,
+    changes: Receiver<HashSet<(V, bool)>>,
+    task_queue: Sender<V>,
+
+}
+
+impl<V: Hash + Eq + PartialEq + Clone> GBrokerManager<V> for GChannelBrokerManager<V>{
+    fn send_assignments(&self, assignment: HashMap<V,bool>){
+        let msg = GMessage::Assignment {assignment};
+        for worker in &self.workers{
+            worker.send(msg.clone()).expect("Sending assignments to workers failed");
+        }
+    }
+    fn queue_task(&self, task: V){
+        self.task_queue.send(task).expect("Sending tasks failed");
+    }
+
+    fn receive_changes(&self) -> Result<HashSet<(V, bool)>, Box<dyn Error>> {
+        match self.changes.recv() {
+            Ok(msg) => Ok(msg),
+            Err(err) => Err(Box::new(err)),
+        }
+    }
+
+    fn terminate(&self) {
+        for to in 0..self.workers.len() {
+            let _err = self
+                .workers
+                .get(to as usize)
+                .expect("receiver id out of bounds")
+                .send(GMessage::Terminate);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GChannelBroker<V: Hash + Eq + PartialEq + Clone> {
+    changes: Sender<HashSet<(V, bool)>>,
+    receiver: Receiver<GMessage<V>>,
+    task_queue: Receiver<V>,
+}
+
+impl<V: Hash + Eq + PartialEq + Clone> GBroker<V> for GChannelBroker<V> {
+    fn return_changes(&self, changes: HashSet<(V, bool)>) {
+        self.changes
+            .send(changes)
+            .expect("Failed to send the assignments table to main thread");
+    }
+
+    fn receive(&self) -> Result<Option<GMessage<V>>, Box<dyn Error>> {
+        match self.receiver.try_recv() {
+            Ok(msg) => Ok(Some(msg)),
+            Err(err) => match err {
+                TryRecvError::Empty => {
+                    debug!("nothing to receive");
+                    Ok(None)
+                }
+                TryRecvError::Disconnected => Err(Box::new(err)),
+            },
+        }
+    }
+
+    fn get_task(&self) -> Result<Option<V>, Box<dyn Error>> {
+        match self.task_queue.try_recv() {
+            Ok(vertex) => Ok(Some(vertex)),
+            Err(err) => match err {
+                TryRecvError::Empty => {
+                    debug!("nothing to receive");
+                    Ok(None)
+                }
+                TryRecvError::Disconnected => Err(Box::new(err)),
+            },
+        }
+    }
+}
+
+impl<V: Hash + Eq + PartialEq + Clone> GChannelBroker<V> {
+    pub fn new(worker_count: u64) -> (Vec<Self>, GChannelBrokerManager<V>) {
+        // Create a message channel foreach worker
+        let mut msg_senders = Vec::with_capacity(worker_count as usize);
+        let mut msg_receivers = Vec::with_capacity(worker_count as usize);
+
+        for _ in 0..worker_count {
+            let (sender, receiver) = crossbeam_channel::unbounded();
+            msg_senders.push(sender);
+            msg_receivers.push(receiver);
+        }
+        let (task_tx,task_rx) = crossbeam_channel::unbounded();
+        let (changes_tx, changes_rx) = crossbeam_channel::unbounded();
+
+        let brokers = msg_receivers
+            .drain(..)
+            .map(|receiver| Self {
+                changes: changes_tx.clone(),
+                receiver,
+                task_queue: task_rx.clone(),
+            })
+            .collect();
+
+        let broker_manager = GChannelBrokerManager {
+            workers: msg_senders,
+            changes: changes_rx,
+            task_queue: task_tx,
+        };
+
+        (brokers, broker_manager)
+    }
+}

--- a/atl-checker/src/algorithms/global/com.rs
+++ b/atl-checker/src/algorithms/global/com.rs
@@ -71,7 +71,7 @@ impl<V: Hash + Eq + PartialEq + Clone> GBrokerManager<V> for GChannelBrokerManag
         for to in 0..self.workers.len() {
             let _err = self
                 .workers
-                .get(to as usize)
+                .get(to)
                 .expect("receiver id out of bounds")
                 .send(GMessage::Terminate);
         }

--- a/atl-checker/src/algorithms/global/com.rs
+++ b/atl-checker/src/algorithms/global/com.rs
@@ -5,8 +5,14 @@ use std::hash::Hash;
 
 #[derive(Clone, Debug)]
 pub enum GMessage<V: Hash + Eq + PartialEq + Clone> {
-    Updates { updates: HashMap<V, bool>, iteration: usize },
-    Result { task: V, value: bool},
+    Updates {
+        updates: HashMap<V, bool>,
+        iteration: usize,
+    },
+    Result {
+        task: V,
+        value: bool,
+    },
     Terminate,
 }
 
@@ -32,7 +38,10 @@ pub struct GChannelBrokerManager<V: Hash + Eq + PartialEq + Clone> {
 
 impl<V: Hash + Eq + PartialEq + Clone> GBrokerManager<V> for GChannelBrokerManager<V> {
     fn send_updates(&self, updates: HashMap<V, bool>, iterations: usize) {
-        let msg = GMessage::Updates { updates, iteration: iterations };
+        let msg = GMessage::Updates {
+            updates,
+            iteration: iterations,
+        };
         for worker in &self.workers {
             worker
                 .send(msg.clone())
@@ -57,7 +66,6 @@ impl<V: Hash + Eq + PartialEq + Clone> GBrokerManager<V> for GChannelBrokerManag
             },
         }
     }
-
 
     fn terminate(&self) {
         for to in 0..self.workers.len() {
@@ -86,7 +94,7 @@ impl<V: Hash + Eq + PartialEq + Clone> GBroker<V> for GChannelBroker<V> {
 
     fn send_result(&self, task: V, value: bool) {
         self.updates
-            .send(GMessage::Result { task, value})
+            .send(GMessage::Result { task, value })
             .expect("Failed to send the result");
     }
 
@@ -103,7 +111,7 @@ impl<V: Hash + Eq + PartialEq + Clone> GBroker<V> for GChannelBroker<V> {
         }
     }
 
-    fn get_task(&self) -> Result<Option<(V,usize)>, Box<dyn Error>> {
+    fn get_task(&self) -> Result<Option<(V, usize)>, Box<dyn Error>> {
         match self.task_queue_consumer.try_recv() {
             Ok(t) => Ok(Some(t)),
             Err(err) => match err {
@@ -115,7 +123,6 @@ impl<V: Hash + Eq + PartialEq + Clone> GBroker<V> for GChannelBroker<V> {
             },
         }
     }
-
 }
 
 impl<V: Hash + Eq + PartialEq + Clone> GChannelBroker<V> {

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -28,7 +28,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
             .rev()
             .for_each(|component| while self.f(component) {});
 
-        *self.assignment().get(&self.v0()).unwrap()
+        *self.assignment().get(self.v0()).unwrap()
     }
 
     /// The resemblance of the function described in the paper, but in order to
@@ -102,7 +102,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
         let v = self.v0().clone();
         self.assignment_mut().insert(v, false);
 
-        for edge in self.edg().succ(&self.v0()) {
+        for edge in self.edg().succ(self.v0()) {
             queue.push_back((edge, 0));
         }
 

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -2,17 +2,17 @@ mod com;
 pub mod multithread;
 pub mod singlethread;
 
-use std::cmp::max;
 use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex};
+use std::cmp::max;
 use std::collections::{HashMap, HashSet, VecDeque};
 
-pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
+pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
     fn edg(&self) -> &G;
     fn edg_mut(&mut self) -> &mut G;
     fn v0(&self) -> &V;
     fn v0_mut(&mut self) -> &mut V;
-    fn assignment(&self) -> &HashMap<V,bool>;
-    fn assignment_mut(&mut self) -> &mut HashMap<V,bool>;
+    fn assignment(&self) -> &HashMap<V, bool>;
+    fn assignment_mut(&mut self) -> &mut HashMap<V, bool>;
     fn dist(&self) -> &VecDeque<HashSet<V>>;
     fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>>;
 
@@ -27,7 +27,6 @@ pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
             .iter()
             .rev()
             .for_each(|mut component| while self.f(&mut component) {});
-
 
         *self.assignment().get(&self.v0()).unwrap()
     }

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -26,7 +26,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
         components
             .iter()
             .rev()
-            .for_each(|mut component| while self.f(&mut component) {});
+            .for_each(|component| while self.f(component) {});
 
         *self.assignment().get(&self.v0()).unwrap()
     }
@@ -100,7 +100,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
         curr_dist.insert(self.v0().clone());
         self.dist_mut().push_front(curr_dist);
         let v = self.v0().clone();
-        self.assignment_mut().insert(v.clone(), false);
+        self.assignment_mut().insert(v, false);
 
         for edge in self.edg().succ(&self.v0()) {
             queue.push_back((edge, 0));

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -1,27 +1,41 @@
 mod com;
-mod multithread;
-mod singlethread;
+pub mod multithread;
+pub mod singlethread;
 
-use std::borrow::{Borrow, BorrowMut};
 use std::cmp::max;
 use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::Debug;
-use crate::algorithms::global::singlethread::SingleThreadedGlobalAlgorithm;
 
 pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
     fn edg(&self) -> &G;
     fn edg_mut(&mut self) -> &mut G;
-    fn v_zero(&self) -> &V;
+    fn v0(&self) -> &V;
+    fn v0_mut(&mut self) -> &mut V;
     fn assignment(&self) -> &HashMap<V,bool>;
     fn assignment_mut(&mut self) -> &mut HashMap<V,bool>;
+    fn dist(&self) -> &VecDeque<HashSet<V>>;
+    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>>;
 
-    fn run(&mut self)-> bool;
+    /// Firing the global algorithm, which simply reapplies the F_i function explained in the paper
+    /// until the assignment does not change anymore.
+    /// Lastly the assignment of the root, v0, is returned
+    fn run(&mut self) -> bool {
+        self.initialize();
+
+        let components = self.dist().clone();
+        components
+            .iter()
+            .rev()
+            .for_each(|mut component| while self.f(&mut component) {});
+
+
+        *self.assignment().get(&self.v0()).unwrap()
+    }
 
     /// The resemblance of the function described in the paper, but in order to
     /// know which component we are worker with and the assignments of the component
-    /// before, these are both given as arguments. The function it self returns a boolean
-    /// which is true if the assignments are changed.
+    /// before, these are both given as arguments.
+    /// The function it self returns a boolean which is true if the assignments are changed.
     fn f(&mut self, component: &HashSet<V>) -> bool {
         let mut changed_flag = false;
 
@@ -67,8 +81,8 @@ pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
     }
 
     /// Updating an assignment to the new_ass value, if the new_ass are
-    /// equal to the old assignment, we simply return. The return value
-    /// is based on whether the assignment of the given vertex is changed or not.
+    /// equal to the old assignment, we simply return.
+    /// The return value is based on whether the assignment of the given vertex is changed or not.
     fn update_assignment(&mut self, v: V, new_ass: bool) -> bool {
         self.assignment_mut()
             .get_mut(&v)
@@ -79,257 +93,75 @@ pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
             })
             .unwrap()
     }
-}
 
+    /// Initialize the dist and assignments by traversing through all edges from root
+    fn initialize(&mut self) {
+        let mut queue = VecDeque::<(Edge<V>, u32)>::new();
+        let mut curr_dist = HashSet::<V>::new();
+        curr_dist.insert(self.v0().clone());
+        self.dist_mut().push_front(curr_dist);
+        let v = self.v0().clone();
+        self.assignment_mut().insert(v.clone(), false);
 
+        for edge in self.edg().succ(&self.v0()) {
+            queue.push_back((edge, 0));
+        }
 
-#[cfg(test)]
-mod test {
-    use test_env_log::test;
-    #[allow(unused_macros)]
-    macro_rules! edg_assert {
-        // Standard use, no names or worker count given
-        ( $v:ident, $assign:expr ) => {
-            edg_assert!([SimpleEDG, SimpleVertex] $v, $assign)
-        };
-        // With custom names and worker count
-        ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:expr) => {
-            assert_eq!(
-                crate::algorithms::global::SingleThreadedGlobalAlgorithm::new($edg_name, $vertex_name::$v).run(),
-                $assign,
-                "Vertex {}",
-                stringify!($v)
-            );
-        };
+        loop {
+            match queue.pop_front() {
+                None => break,
+                Some((edge, dist)) => {
+                    self.initialize_from_edge(edge, &mut queue, dist);
+                }
+            }
+        }
     }
 
-    #[test]
-    fn test_global_algorithm_empty_hyper_edge() {
-        simple_edg![
-            A => -> {};
-        ];
-        edg_assert!(A, true);
+    /// A helper function to initialize(), which assign and targets `false` and insert
+    /// them into the `dist` list. If the target already is know, it is simply skipped
+    fn initialize_from_edge(
+        &mut self,
+        edge: Edge<V>,
+        queue: &mut VecDeque<(Edge<V>, u32)>,
+        dist: u32,
+    ) {
+        match edge {
+            Edge::Hyper(e) => {
+                for target in e.targets {
+                    if self.assignment().get(&target).is_some() {
+                        continue;
+                    }
+                    self.assignment_mut().insert(target.clone(), false);
+                    self.insert_in_curr_dist(target.clone(), dist);
+                    for target_edge in self.edg().succ(&target) {
+                        queue.push_front((target_edge, dist));
+                    }
+                }
+            }
+
+            Edge::Negation(e) => {
+                if self.assignment().get(&e.target).is_none() {
+                    self.assignment_mut().insert(e.target.clone(), false);
+                    self.insert_in_curr_dist(e.target.clone(), dist + 1);
+                    for target_edge in self.edg().succ(&e.target) {
+                        queue.push_front((target_edge, dist + 1))
+                    }
+                }
+            }
+        }
     }
 
-    #[test]
-    fn test_global_algorithm_no_successors() {
-        simple_edg![
-            A => ;
-        ];
-        edg_assert!(A, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_01() {
-        simple_edg![
-            A => -> {B, C} -> {D};
-            B => ;
-            C => .> D;
-            D => -> {};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-        edg_assert!(D, true);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_02() {
-        simple_edg![
-            A => -> {B, C};
-            B => .> E;
-            C => -> {};
-            D => -> {} -> {C};
-            E => .> D;
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-        edg_assert!(E, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_03() {
-        simple_edg![
-            A => -> {B} -> {E};
-            B => -> {C};
-            C => -> {F} -> {H};
-            D => -> {E} -> {C};
-            E => -> {D, F};
-            F => -> {};
-            G => .> A;
-            H => -> {I};
-            I => ;
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-        edg_assert!(E, true);
-        edg_assert!(F, true);
-        edg_assert!(G, false);
-        edg_assert!(H, false);
-        edg_assert!(I, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_04() {
-        simple_edg![
-            A => -> {B} -> {C};
-            B => -> {D};
-            C => ;
-            D => -> {};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, false);
-        edg_assert!(D, true);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_05() {
-        simple_edg![
-            A => -> {B};
-            B => -> {C};
-            C => -> {B};
-        ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_06() {
-        simple_edg![
-            A => -> {B} -> {C};
-            B => ;
-            C => ;
-        ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_07() {
-        simple_edg![
-            A => -> {B};
-            B => -> {A, C};
-            C => -> {D};
-            D => -> {};
-        ];
-        edg_assert!(A, false);
-        edg_assert!(B, false);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-    }
-
-    #[test]
-    fn test_global_algorithm_general_08() {
-        simple_edg![
-            A => -> {B, C};
-            B => -> {C} -> {D};
-            C => -> {B};
-            D => -> {C} -> {};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, true);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_01() {
-        simple_edg![
-            A => .> B;
-            B => -> {};
-        ];
-        edg_assert!(A, false);
-        edg_assert!(B, true);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_02() {
-        simple_edg![
-            A => .> B;
-            B => -> {C};
-            C => -> {B} .> D;
-            D => -> {E};
-            E => -> {D};
-        ];
-        edg_assert!(A, false);
-        edg_assert!(B, true);
-        edg_assert!(C, true);
-        edg_assert!(D, false);
-        edg_assert!(E, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_03() {
-        simple_edg![
-            A => .> B .> C;
-            B => .> D;
-            C => -> {D};
-            D => ;
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, true);
-        edg_assert!(C, false);
-        edg_assert!(D, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_04() {
-        simple_edg![
-            A => .> B;
-            B => -> {B};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_05() {
-        simple_edg![
-            A => .> B;
-            B => .> C;
-            C => .> D;
-            D => .> E;
-            E => .> F;
-            F => -> {F};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, true);
-        edg_assert!(D, false);
-        edg_assert!(E, true);
-        edg_assert!(F, false);
-    }
-
-    #[test]
-    fn test_global_algorithm_negation_to_undecided_01() {
-        // A case where we might explore and find a negation edges to something that is
-        // currently assigned undecided
-        simple_edg![
-            A => .> B .> E;
-            B => -> {C};
-            C => -> {D};
-            D => .> E;
-            E => -> {F};
-            F => -> {G};
-            G => -> {H};
-            H => -> {I};
-            I => -> {J};
-            J => -> {K};
-            K => -> {};
-        ];
-        edg_assert!(A, true);
-        edg_assert!(B, false);
-        edg_assert!(C, false);
-        edg_assert!(D, false);
-        edg_assert!(E, true);
-        edg_assert!(F, true);
-        edg_assert!(G, true);
+    /// Inserts a vertex in the set at the index of curr_dist of dist.
+    fn insert_in_curr_dist(&mut self, v: V, dist: u32) {
+        match self.dist_mut().get_mut(dist as usize) {
+            None => {
+                let mut curr_dist = HashSet::<V>::new();
+                curr_dist.insert(v);
+                self.dist_mut().insert(dist as usize, curr_dist);
+            }
+            Some(set) => {
+                set.insert(v);
+            }
+        }
     }
 }

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -1,111 +1,22 @@
-use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex};
+mod com;
+mod multithread;
+mod singlethread;
+
+use std::borrow::{Borrow, BorrowMut};
 use std::cmp::max;
+use crate::edg::{Edge, ExtendedDependencyGraph, HyperEdge, NegationEdge, Vertex};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Debug;
+use crate::algorithms::global::singlethread::SingleThreadedGlobalAlgorithm;
 
-// Based on the global algorithm described in "Extended Dependency Graphs and Efficient Distributed Fixed-Point Computation" by A.E. Dalsgaard et al., 2017
-pub struct GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
-    edg: G,
-    /// The root vertex, which we discover the graph from
-    v0: V,
-    /// The assignment for all vertices, we use this to keep track  of the current assignment
-    assignment: HashMap<V, bool>,
-    /// The distance of a vertex is represented as the index number of which set the vertex is located in
-    dist: VecDeque<HashSet<V>>,
-}
+pub trait GlobalAlgorithm<G:ExtendedDependencyGraph<V>, V: Vertex>{
+    fn edg(&self) -> &G;
+    fn edg_mut(&mut self) -> &mut G;
+    fn v_zero(&self) -> &V;
+    fn assignment(&self) -> &HashMap<V,bool>;
+    fn assignment_mut(&mut self) -> &mut HashMap<V,bool>;
 
-impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
-    pub fn new(edg: G, v0: V) -> Self {
-        Self {
-            edg,
-            v0,
-            assignment: HashMap::<V, bool>::new(),
-            dist: VecDeque::<HashSet<V>>::new(),
-        }
-    }
-
-    /// Firing the global algorithm, which simply reapplies the F_i function explained in the paper
-    /// until the assignment does not change anymore. Lastly the assignment of the root, v0, is returned
-    pub fn run(&mut self) -> bool {
-        self.initialize();
-
-        let components = self.dist.clone();
-        components
-            .iter()
-            .rev()
-            .for_each(|component| while self.f(&component) {});
-        *self.assignment.get(&self.v0).unwrap()
-    }
-
-    /// Initialize the dist and assignments by traversing through all edges from root
-    fn initialize(&mut self) {
-        let mut queue = VecDeque::<(Edge<V>, u32)>::new();
-        let mut curr_dist = HashSet::<V>::new();
-        curr_dist.insert(self.v0.clone());
-        self.dist.push_front(curr_dist);
-
-        self.assignment.insert(self.v0.clone(), false);
-
-        for edge in self.edg.succ(&self.v0) {
-            queue.push_back((edge, 0));
-        }
-
-        loop {
-            match queue.pop_front() {
-                None => break,
-                Some((edge, dist)) => {
-                    self.initialize_from_edge(edge, &mut queue, dist);
-                }
-            }
-        }
-    }
-
-    /// A helper function to initialize(), which assign and targets `false` and insert
-    /// them into the `dist` list. If the target already is know, it is simply skipped
-    fn initialize_from_edge(
-        &mut self,
-        edge: Edge<V>,
-        queue: &mut VecDeque<(Edge<V>, u32)>,
-        dist: u32,
-    ) {
-        match edge {
-            Edge::Hyper(e) => {
-                for target in e.targets {
-                    if self.assignment.get(&target).is_some() {
-                        continue;
-                    }
-                    self.assignment.insert(target.clone(), false);
-                    self.insert_in_curr_dist(target.clone(), dist);
-                    for target_edge in self.edg.succ(&target) {
-                        queue.push_front((target_edge, dist));
-                    }
-                }
-            }
-
-            Edge::Negation(e) => {
-                if self.assignment.get(&e.target).is_none() {
-                    self.assignment.insert(e.target.clone(), false);
-                    self.insert_in_curr_dist(e.target.clone(), dist + 1);
-                    for target_edge in self.edg.succ(&e.target) {
-                        queue.push_front((target_edge, dist + 1))
-                    }
-                }
-            }
-        }
-    }
-
-    /// Inserts a vertex in the set at the index of curr_dist of dist.
-    fn insert_in_curr_dist(&mut self, v: V, dist: u32) {
-        match self.dist.get_mut(dist as usize) {
-            None => {
-                let mut curr_dist = HashSet::<V>::new();
-                curr_dist.insert(v);
-                self.dist.insert(dist as usize, curr_dist);
-            }
-            Some(set) => {
-                set.insert(v);
-            }
-        }
-    }
+    fn run(&mut self)-> bool;
 
     /// The resemblance of the function described in the paper, but in order to
     /// know which component we are worker with and the assignments of the component
@@ -115,7 +26,7 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
         let mut changed_flag = false;
 
         for vertex in component {
-            for edge in self.edg.succ(vertex) {
+            for edge in self.edg().succ(vertex) {
                 match edge {
                     Edge::Hyper(e) => changed_flag = max(self.process_hyper(e), changed_flag),
                     Edge::Negation(e) => changed_flag = max(self.process_negation(e), changed_flag),
@@ -129,12 +40,12 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
     /// source vertex already is true we simply return. The return value is based on if a changed
     /// have been made.
     fn process_hyper(&mut self, edge: HyperEdge<V>) -> bool {
-        if *self.assignment.get(&edge.source).unwrap() {
+        if *self.assignment().get(&edge.source).unwrap() {
             false
         } else {
             let mut final_ass = true;
             for target in edge.targets {
-                if !self.assignment.get(&target).unwrap() {
+                if !self.assignment().get(&target).unwrap() {
                     final_ass = false;
                     break;
                 }
@@ -147,10 +58,10 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
     /// false in the last component assignment. If the source vertex already is true we
     /// simply return. The return value is based on if a changed have been made.
     fn process_negation(&mut self, edge: NegationEdge<V>) -> bool {
-        if *self.assignment.get(&edge.source).unwrap() {
+        if *self.assignment().get(&edge.source).unwrap() {
             false
         } else {
-            let new_ass = !*self.assignment.get(&edge.target).unwrap();
+            let new_ass = !*self.assignment().get(&edge.target).unwrap();
             self.update_assignment(edge.source, new_ass)
         }
     }
@@ -159,7 +70,7 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
     /// equal to the old assignment, we simply return. The return value
     /// is based on whether the assignment of the given vertex is changed or not.
     fn update_assignment(&mut self, v: V, new_ass: bool) -> bool {
-        self.assignment
+        self.assignment_mut()
             .get_mut(&v)
             .map(|ass| {
                 let old = *ass;
@@ -169,6 +80,9 @@ impl<G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G, V> {
             .unwrap()
     }
 }
+
+
+
 #[cfg(test)]
 mod test {
     use test_env_log::test;
@@ -181,7 +95,7 @@ mod test {
         // With custom names and worker count
         ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:expr) => {
             assert_eq!(
-                crate::algorithms::global::GlobalAlgorithm::new($edg_name, $vertex_name::$v).run(),
+                crate::algorithms::global::SingleThreadedGlobalAlgorithm::new($edg_name, $vertex_name::$v).run(),
                 $assign,
                 "Vertex {}",
                 stringify!($v)

--- a/atl-checker/src/algorithms/global/mod.rs
+++ b/atl-checker/src/algorithms/global/mod.rs
@@ -13,8 +13,8 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
     fn v0_mut(&mut self) -> &mut V;
     fn assignment(&self) -> &HashMap<V, bool>;
     fn assignment_mut(&mut self) -> &mut HashMap<V, bool>;
-    fn dist(&self) -> &VecDeque<HashSet<V>>;
-    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>>;
+    fn components(&self) -> &VecDeque<HashSet<V>>;
+    fn components_mut(&mut self) -> &mut VecDeque<HashSet<V>>;
 
     /// Firing the global algorithm, which simply reapplies the F_i function explained in the paper
     /// until the assignment does not change anymore.
@@ -22,7 +22,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
     fn run(&mut self) -> bool {
         self.initialize();
 
-        let components = self.dist().clone();
+        let components = self.components().clone();
         components
             .iter()
             .rev()
@@ -98,7 +98,7 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
         let mut queue = VecDeque::<(Edge<V>, u32)>::new();
         let mut curr_dist = HashSet::<V>::new();
         curr_dist.insert(self.v0().clone());
-        self.dist_mut().push_front(curr_dist);
+        self.components_mut().push_front(curr_dist);
         let v = self.v0().clone();
         self.assignment_mut().insert(v, false);
 
@@ -152,11 +152,11 @@ pub trait GlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
 
     /// Inserts a vertex in the set at the index of curr_dist of dist.
     fn insert_in_curr_dist(&mut self, v: V, dist: u32) {
-        match self.dist_mut().get_mut(dist as usize) {
+        match self.components_mut().get_mut(dist as usize) {
             None => {
                 let mut curr_dist = HashSet::<V>::new();
                 curr_dist.insert(v);
-                self.dist_mut().insert(dist as usize, curr_dist);
+                self.components_mut().insert(dist as usize, curr_dist);
             }
             Some(set) => {
                 set.insert(v);

--- a/atl-checker/src/algorithms/global/multithread.rs
+++ b/atl-checker/src/algorithms/global/multithread.rs
@@ -1,0 +1,464 @@
+use std::cmp::max;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Debug;
+use std::thread;
+use tracing::{span, trace, Level};
+
+use crate::algorithms::global::com::{GBroker, GBrokerManager, GChannelBroker, GChannelBrokerManager, GMessage};
+use crate::algorithms::global::com::GMessage::{Terminate, Updates};
+use crate::algorithms::global::GlobalAlgorithm;
+use crate::edg::{Edge, ExtendedDependencyGraph, Vertex};
+
+
+pub struct GWorker<B: GBroker<V>, G: ExtendedDependencyGraph<V>, V: Vertex>{
+    edg: G,
+    assignment: HashMap<V,bool>,
+    broker: B,
+}
+
+
+impl <B: GBroker<V>, G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G,V> for GWorker<B,G,V>  {
+    fn edg(&self) -> &G {
+        &self.edg
+    }
+    fn edg_mut(&mut self) -> &mut G {
+        &mut self.edg
+    }
+    fn v0(&self) -> &V {
+        panic!("A GWorker doesnt have a v0 value")
+    }
+    fn v0_mut(&mut self) -> &mut V {
+        panic!("A GWorker doesnt have a v0 value")
+    }
+    fn assignment(&self) -> &HashMap<V, bool> {
+        &self.assignment
+    }
+    fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
+        &mut self.assignment
+    }
+    fn dist(&self) -> &VecDeque<HashSet<V>> {
+        panic!("A GWorker doesnt have a dist vecdeque")
+    }
+    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>> {
+        panic!("A GWorker doesnt have a dist vecdeque")
+    }
+    fn run(&mut self) -> bool {
+        self.run()
+    }
+}
+
+impl<B: GBroker<V>, G: ExtendedDependencyGraph<V>,  V: Vertex> GWorker<B,G,V>{
+    pub fn new(edg: G, assignment: HashMap<V,bool>, broker: B) -> Self {
+        trace!(
+            "new global worker"
+        );
+        Self {
+            edg,
+            assignment,
+            broker,
+        }
+    }
+
+    pub fn run(&mut self) -> bool {
+        let span = span!(Level::DEBUG, "worker run");
+        let _enter = span.enter();
+        trace!("worker start");
+        emit_count!("worker start");
+        loop {
+            match self.broker.receive(){
+                Ok(msg) => {
+                    if let Some(Updates { updates: assignment }) = msg {
+                        trace!("Worker received updates");
+                        assignment
+                            .iter()
+                            .for_each(|(k,v)|{
+                                self.update_assignment(k.clone(), *v);
+                            });
+                    } else if let Some(Terminate) = msg {
+                        trace!("Worker received terminate");
+                        return true;
+                    }
+                }
+                Err(err) => panic!("{}", err),
+            }
+
+            if let Ok(Some(task)) = self.broker.get_task() {
+                trace!("Worker received task");
+                if !self.assignment().contains_key(&task) {
+                    self.assignment_mut().insert(task.clone(), false);
+                }
+                for edge in self.edg.succ(&task) {
+                    match edge {
+                        Edge::Hyper(e) => { self.process_hyper(e); }
+                        Edge::Negation(e) => { self.process_negation(e); }
+                    }
+                    trace!("Worker finished task");
+                }
+                self.broker.send_result(task.clone(), *self.assignment.get(&task).unwrap());
+            }
+        }
+    }
+}
+
+pub struct MultithreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
+    edg: G,
+    worker_count: u64,
+    v0: V,
+    assignment: HashMap<V, bool>,
+    dist: VecDeque<HashSet<V>>,
+}
+
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> GlobalAlgorithm<G,V> for MultithreadedGlobalAlgorithm<G,V> {
+    fn edg(&self) -> &G {
+        &self.edg
+    }
+    fn edg_mut(&mut self) -> &mut G {
+        &mut self.edg
+    }
+    fn v0(&self) -> &V {
+        &self.v0
+    }
+    fn v0_mut(&mut self) -> &mut V {
+        &mut self.v0
+    }
+    fn assignment(&self) -> &HashMap<V, bool> {
+        &self.assignment
+    }
+    fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
+        &mut self.assignment
+    }
+    fn dist(&self) -> &VecDeque<HashSet<V>> {
+        &self.dist
+    }
+    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>> {
+        &mut self.dist
+    }
+
+    fn run(&mut self) -> bool {
+        self.initialize();
+
+        let (mut brokers, manager) = GChannelBroker::new(self.worker_count);
+        for _ in 0..self.worker_count {
+            let mut worker = GWorker::new(
+                self.edg.clone(),
+                self.assignment.clone(),
+                brokers.pop().unwrap()
+            );
+            thread::spawn(move || {
+                worker.run();
+            });
+        }
+
+        let components = self.dist.clone();
+        components
+            .iter()
+            .rev()
+            .for_each(|component| {
+                let mut tasks: HashMap<V, bool> = HashMap::new();
+                let mut changed_flag = true;
+
+                for vertex in component {
+                    self.queue_task(vertex.clone(),&mut tasks,&manager);
+                }
+
+                loop {
+                    if !tasks.values().any(|value| *value)  {
+                        if manager.task_queue_is_empty() && !changed_flag { break; }
+
+                        manager.send_updates(self.assignment().clone());
+                        for vertex in component {
+                            self.queue_task(vertex.clone(),&mut tasks, &manager);
+                        }
+                        changed_flag = false;
+                    }
+
+                    match manager.receive() {
+                        Ok(msg) => {
+                            if let GMessage::Result { task, value } = msg {
+                                changed_flag = max(self.update_assignment(task.clone(), value.clone()), changed_flag);
+                                tasks.insert(task, false);
+                            }
+                        }
+                        Err(err) => { panic!("{}", err); }
+                    }
+                }
+            });
+
+        manager.terminate();
+        *self.assignment().get(&self.v0).unwrap()
+    }
+}
+
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> MultithreadedGlobalAlgorithm<G, V> {
+    pub fn new(edg: G, worker_count: u64, v0: V) -> Self {
+        let mut assignment = HashMap::new();
+        assignment.insert(v0.clone(),false);
+        let dist = VecDeque::new();
+        Self {
+            edg,
+            worker_count,
+            v0,
+            assignment,
+            dist,
+        }
+    }
+    pub fn run(&mut self) -> bool {
+        GlobalAlgorithm::<G,V>::run(self)
+    }
+
+    fn queue_task(&self, task: V,tasks: &mut HashMap<V, bool>, manager: &GChannelBrokerManager<V>){
+        tasks.insert(task.clone(), true);
+        manager.queue_task( task.clone());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_env_log::test;
+    #[allow(unused_macros)]
+    macro_rules! edg_multi_assert {
+        ( $v:ident, $assign:expr ) => {
+                edg_multi_assert!([SimpleEDG, SimpleVertex] $v, $assign)
+        };
+        // With custom names
+        ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:expr) => {
+            assert_eq!(
+                crate::algorithms::global::multithread::MultithreadedGlobalAlgorithm::new($edg_name, 1,$vertex_name::$v).run(),
+                $assign,
+                "Vertex {}",
+                stringify!($v)
+            );
+        };
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_empty_hyper_edge() {
+        simple_edg![
+            A => -> {};
+        ];
+        edg_multi_assert!(A, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_no_successors() {
+        simple_edg![
+            A => ;
+        ];
+        edg_multi_assert!(A, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_01() {
+        simple_edg![
+            A => -> {B, C} -> {D};
+            B => ;
+            C => .> D;
+            D => -> {};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, false);
+        edg_multi_assert!(D, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_02() {
+        simple_edg![
+            A => -> {B, C};
+            B => .> E;
+            C => -> {};
+            D => -> {} -> {C};
+            E => .> D;
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, true);
+        edg_multi_assert!(E, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_03() {
+        simple_edg![
+            A => -> {B} -> {E};
+            B => -> {C};
+            C => -> {F} -> {H};
+            D => -> {E} -> {C};
+            E => -> {D, F};
+            F => -> {};
+            G => .> A;
+            H => -> {I};
+            I => ;
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, true);
+        edg_multi_assert!(E, true);
+        edg_multi_assert!(F, true);
+        edg_multi_assert!(G, false);
+        edg_multi_assert!(H, false);
+        edg_multi_assert!(I, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_04() {
+        simple_edg![
+            A => -> {B} -> {C};
+            B => -> {D};
+            C => ;
+            D => -> {};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, false);
+        edg_multi_assert!(D, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_05() {
+        simple_edg![
+            A => -> {B};
+            B => -> {C};
+            C => -> {B};
+        ];
+        edg_multi_assert!(A, false);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_06() {
+        simple_edg![
+            A => -> {B} -> {C};
+            B => ;
+            C => ;
+        ];
+        edg_multi_assert!(A, false);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_07() {
+        simple_edg![
+            A => -> {B};
+            B => -> {A, C};
+            C => -> {D};
+            D => -> {};
+        ];
+        edg_multi_assert!(A, false);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_general_08() {
+        simple_edg![
+            A => -> {B, C};
+            B => -> {C} -> {D};
+            C => -> {B};
+            D => -> {C} -> {};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_01() {
+        simple_edg![
+            A => .> B;
+            B => -> {};
+        ];
+        edg_multi_assert!(A, false);
+        edg_multi_assert!(B, true);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_02() {
+        simple_edg![
+            A => .> B;
+            B => -> {C};
+            C => -> {B} .> D;
+            D => -> {E};
+            E => -> {D};
+        ];
+        edg_multi_assert!(A, false);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, false);
+        edg_multi_assert!(E, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_03() {
+        simple_edg![
+            A => .> B .> C;
+            B => .> D;
+            C => -> {D};
+            D => ;
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, true);
+        edg_multi_assert!(C, false);
+        edg_multi_assert!(D, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_04() {
+        simple_edg![
+            A => .> B;
+            B => -> {B};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_05() {
+        simple_edg![
+            A => .> B;
+            B => .> C;
+            C => .> D;
+            D => .> E;
+            E => .> F;
+            F => -> {F};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, true);
+        edg_multi_assert!(D, false);
+        edg_multi_assert!(E, true);
+        edg_multi_assert!(F, false);
+    }
+
+    #[test]
+    fn test_multi_global_algorithm_negation_to_undecided_01() {
+        // A case where we might explore and find a negation edges to something that is
+        // currently assigned undecided
+        simple_edg![
+            A => .> B .> E;
+            B => -> {C};
+            C => -> {D};
+            D => .> E;
+            E => -> {F};
+            F => -> {G};
+            G => -> {H};
+            H => -> {I};
+            I => -> {J};
+            J => -> {K};
+            K => -> {};
+        ];
+        edg_multi_assert!(A, true);
+        edg_multi_assert!(B, false);
+        edg_multi_assert!(C, false);
+        edg_multi_assert!(D, false);
+        edg_multi_assert!(E, true);
+        edg_multi_assert!(F, true);
+        edg_multi_assert!(G, true);
+    }
+}
+

--- a/atl-checker/src/algorithms/global/multithread.rs
+++ b/atl-checker/src/algorithms/global/multithread.rs
@@ -70,7 +70,6 @@ impl<B: GBroker<V>, G: ExtendedDependencyGraph<V>, V: Vertex> GlobalAlgorithm<G,
         let mut curr_task = None;
         // The worker simple consumes the work queue until a termination notification is received
         loop {
-
             // Check if there is updates or a termination notification is received.
             // If there is updates update the assignment table and the current iteration.
             // If it is a termination notification return.

--- a/atl-checker/src/algorithms/global/multithread.rs
+++ b/atl-checker/src/algorithms/global/multithread.rs
@@ -184,10 +184,8 @@ impl<
                 match manager.receive() {
                     Ok(msg) => {
                         if let GMessage::Result { task, value } = msg {
-                            changed_flag = max(
-                                self.update_assignment(task.clone(), value.clone()),
-                                changed_flag,
-                            );
+                            changed_flag =
+                                max(self.update_assignment(task.clone(), value), changed_flag);
                             tasks.insert(task, false);
                         }
                     }
@@ -231,7 +229,7 @@ impl<
         manager: &GChannelBrokerManager<V>,
     ) {
         tasks.insert(task.clone(), true);
-        manager.queue_task(task.clone());
+        manager.queue_task(task);
     }
 }
 

--- a/atl-checker/src/algorithms/global/singlethread.rs
+++ b/atl-checker/src/algorithms/global/singlethread.rs
@@ -1,0 +1,135 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Debug;
+use crate::algorithms::global::GlobalAlgorithm;
+use crate::algorithms::global::multithread::MultithreadedGlobalAlgorithm;
+use crate::edg::{Edge, ExtendedDependencyGraph, Vertex};
+
+// Based on the global algorithm described in "Extended Dependency Graphs and Efficient Distributed Fixed-Point Computation" by A.E. Dalsgaard et al., 2017
+pub struct SingleThreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
+    edg: G,
+    /// The root vertex, which we discover the graph from
+    v0: V,
+    /// The assignment for all vertices, we use this to keep track  of the current assignment
+    assignment: HashMap<V, bool>,
+    /// The distance of a vertex is represented as the index number of which set the vertex is located in
+    dist: VecDeque<HashSet<V>>,
+}
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> SingleThreadedGlobalAlgorithm<G,V>{
+    pub fn run(mut self)->bool{
+        GlobalAlgorithm::<G,V>::run(&mut self)
+    }
+
+    pub fn new(edg: G,v0: V) -> Self {
+        Self {
+            edg,
+            v0,
+            assignment: HashMap::<V, bool>::new(),
+            dist: VecDeque::<HashSet<V>>::new(),
+        }
+    }
+
+    /// Initialize the dist and assignments by traversing through all edges from root
+    fn initialize(&mut self) {
+        let mut queue = VecDeque::<(Edge<V>, u32)>::new();
+        let mut curr_dist = HashSet::<V>::new();
+        curr_dist.insert(self.v0.clone());
+        self.dist.push_front(curr_dist);
+
+        self.assignment.insert(self.v0.clone(), false);
+
+        for edge in self.edg.succ(&self.v0) {
+            queue.push_back((edge, 0));
+        }
+
+        loop {
+            match queue.pop_front() {
+                None => break,
+                Some((edge, dist)) => {
+                    self.initialize_from_edge(edge, &mut queue, dist);
+                }
+            }
+        }
+    }
+
+    /// A helper function to initialize(), which assign and targets `false` and insert
+    /// them into the `dist` list. If the target already is know, it is simply skipped
+    fn initialize_from_edge(
+        &mut self,
+        edge: Edge<V>,
+        queue: &mut VecDeque<(Edge<V>, u32)>,
+        dist: u32,
+    ) {
+        match edge {
+            Edge::Hyper(e) => {
+                for target in e.targets {
+                    if self.assignment.get(&target).is_some() {
+                        continue;
+                    }
+                    self.assignment.insert(target.clone(), false);
+                    self.insert_in_curr_dist(target.clone(), dist);
+                    for target_edge in self.edg.succ(&target) {
+                        queue.push_front((target_edge, dist));
+                    }
+                }
+            }
+
+            Edge::Negation(e) => {
+                if self.assignment.get(&e.target).is_none() {
+                    self.assignment.insert(e.target.clone(), false);
+                    self.insert_in_curr_dist(e.target.clone(), dist + 1);
+                    for target_edge in self.edg.succ(&e.target) {
+                        queue.push_front((target_edge, dist + 1))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Inserts a vertex in the set at the index of curr_dist of dist.
+    fn insert_in_curr_dist(&mut self, v: V, dist: u32) {
+        match self.dist.get_mut(dist as usize) {
+            None => {
+                let mut curr_dist = HashSet::<V>::new();
+                curr_dist.insert(v);
+                self.dist.insert(dist as usize, curr_dist);
+            }
+            Some(set) => {
+                set.insert(v);
+            }
+        }
+    }
+}
+
+
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> GlobalAlgorithm<G,V> for SingleThreadedGlobalAlgorithm<G,V> {
+    fn edg(&self) -> &G {
+        &self.edg
+    }
+    fn edg_mut(&mut self) -> &mut G {
+        &mut self.edg
+
+    }
+    fn v_zero(&self) -> &V {
+        &self.v0
+    }
+    fn assignment(&self) -> &HashMap<V, bool> {
+        &self.assignment
+    }
+    fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
+        &mut self.assignment
+    }
+    /// Firing the global algorithm, which simply reapplies the F_i function explained in the paper
+    /// until the assignment does not change anymore. Lastly the assignment of the root, v0, is returned
+    fn run(&mut self) -> bool {
+        self.initialize();
+
+        let components = self.dist.clone();
+        components
+            .iter()
+            .rev()
+            .for_each(|mut component| while self.f(&mut component) {});
+
+
+        *self.assignment().get(&self.v0).unwrap()
+    }
+}

--- a/atl-checker/src/algorithms/global/singlethread.rs
+++ b/atl-checker/src/algorithms/global/singlethread.rs
@@ -64,7 +64,7 @@ impl<
 
 #[cfg(test)]
 mod test {
-    use test_env_log::test;
+    use test_log::test;
     #[allow(unused_macros)]
     macro_rules! edg_assert {
         // Standard use, no names or worker count given

--- a/atl-checker/src/algorithms/global/singlethread.rs
+++ b/atl-checker/src/algorithms/global/singlethread.rs
@@ -1,11 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use crate::algorithms::global::GlobalAlgorithm;
-use crate::algorithms::global::multithread::MultithreadedGlobalAlgorithm;
-use crate::edg::{Edge, ExtendedDependencyGraph, Vertex};
-
+use crate::edg::{ExtendedDependencyGraph, Vertex};
 // Based on the global algorithm described in "Extended Dependency Graphs and Efficient Distributed Fixed-Point Computation" by A.E. Dalsgaard et al., 2017
-pub struct SingleThreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
+pub struct SinglethreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
     edg: G,
     /// The root vertex, which we discover the graph from
     v0: V,
@@ -14,11 +12,38 @@ pub struct SingleThreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Verte
     /// The distance of a vertex is represented as the index number of which set the vertex is located in
     dist: VecDeque<HashSet<V>>,
 }
-impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> SingleThreadedGlobalAlgorithm<G,V>{
+
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> GlobalAlgorithm<G,V> for SinglethreadedGlobalAlgorithm<G,V> {
+    fn edg(&self) -> &G {
+        &self.edg
+    }
+    fn edg_mut(&mut self) -> &mut G {
+        &mut self.edg
+    }
+    fn v0(&self) -> &V {
+        &self.v0
+    }
+    fn v0_mut(&mut self) -> &mut V {
+        &mut self.v0
+    }
+    fn assignment(&self) -> &HashMap<V, bool> {
+        &self.assignment
+    }
+    fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
+        &mut self.assignment
+    }
+    fn dist(&self) -> &VecDeque<HashSet<V>> {
+        &self.dist
+    }
+    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>> {
+        &mut self.dist
+    }
+}
+
+impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> SinglethreadedGlobalAlgorithm<G,V>{
     pub fn run(mut self)->bool{
         GlobalAlgorithm::<G,V>::run(&mut self)
     }
-
     pub fn new(edg: G,v0: V) -> Self {
         Self {
             edg,
@@ -27,109 +52,255 @@ impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: V
             dist: VecDeque::<HashSet<V>>::new(),
         }
     }
-
-    /// Initialize the dist and assignments by traversing through all edges from root
-    fn initialize(&mut self) {
-        let mut queue = VecDeque::<(Edge<V>, u32)>::new();
-        let mut curr_dist = HashSet::<V>::new();
-        curr_dist.insert(self.v0.clone());
-        self.dist.push_front(curr_dist);
-
-        self.assignment.insert(self.v0.clone(), false);
-
-        for edge in self.edg.succ(&self.v0) {
-            queue.push_back((edge, 0));
-        }
-
-        loop {
-            match queue.pop_front() {
-                None => break,
-                Some((edge, dist)) => {
-                    self.initialize_from_edge(edge, &mut queue, dist);
-                }
-            }
-        }
-    }
-
-    /// A helper function to initialize(), which assign and targets `false` and insert
-    /// them into the `dist` list. If the target already is know, it is simply skipped
-    fn initialize_from_edge(
-        &mut self,
-        edge: Edge<V>,
-        queue: &mut VecDeque<(Edge<V>, u32)>,
-        dist: u32,
-    ) {
-        match edge {
-            Edge::Hyper(e) => {
-                for target in e.targets {
-                    if self.assignment.get(&target).is_some() {
-                        continue;
-                    }
-                    self.assignment.insert(target.clone(), false);
-                    self.insert_in_curr_dist(target.clone(), dist);
-                    for target_edge in self.edg.succ(&target) {
-                        queue.push_front((target_edge, dist));
-                    }
-                }
-            }
-
-            Edge::Negation(e) => {
-                if self.assignment.get(&e.target).is_none() {
-                    self.assignment.insert(e.target.clone(), false);
-                    self.insert_in_curr_dist(e.target.clone(), dist + 1);
-                    for target_edge in self.edg.succ(&e.target) {
-                        queue.push_front((target_edge, dist + 1))
-                    }
-                }
-            }
-        }
-    }
-
-    /// Inserts a vertex in the set at the index of curr_dist of dist.
-    fn insert_in_curr_dist(&mut self, v: V, dist: u32) {
-        match self.dist.get_mut(dist as usize) {
-            None => {
-                let mut curr_dist = HashSet::<V>::new();
-                curr_dist.insert(v);
-                self.dist.insert(dist as usize, curr_dist);
-            }
-            Some(set) => {
-                set.insert(v);
-            }
-        }
-    }
 }
 
-
-impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> GlobalAlgorithm<G,V> for SingleThreadedGlobalAlgorithm<G,V> {
-    fn edg(&self) -> &G {
-        &self.edg
+#[cfg(test)]
+mod test {
+    use test_env_log::test;
+    #[allow(unused_macros)]
+    macro_rules! edg_assert {
+        // Standard use, no names or worker count given
+        ( $v:ident, $assign:expr ) => {
+            edg_assert!([SimpleEDG, SimpleVertex] $v, $assign)
+        };
+        // With custom names and worker count
+        ( [$edg_name:ident, $vertex_name:ident] $v:ident, $assign:expr) => {
+            assert_eq!(
+                crate::algorithms::global::singlethread::SinglethreadedGlobalAlgorithm::new($edg_name, $vertex_name::$v).run(),
+                $assign,
+                "Vertex {}",
+                stringify!($v)
+            );
+        };
     }
-    fn edg_mut(&mut self) -> &mut G {
-        &mut self.edg
 
+    #[test]
+    fn test_global_algorithm_empty_hyper_edge() {
+        simple_edg![
+            A => -> {};
+        ];
+        edg_assert!(A, true);
     }
-    fn v_zero(&self) -> &V {
-        &self.v0
-    }
-    fn assignment(&self) -> &HashMap<V, bool> {
-        &self.assignment
-    }
-    fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
-        &mut self.assignment
-    }
-    /// Firing the global algorithm, which simply reapplies the F_i function explained in the paper
-    /// until the assignment does not change anymore. Lastly the assignment of the root, v0, is returned
-    fn run(&mut self) -> bool {
-        self.initialize();
 
-        let components = self.dist.clone();
-        components
-            .iter()
-            .rev()
-            .for_each(|mut component| while self.f(&mut component) {});
+    #[test]
+    fn test_global_algorithm_no_successors() {
+        simple_edg![
+            A => ;
+        ];
+        edg_assert!(A, false);
+    }
 
+    #[test]
+    fn test_global_algorithm_general_01() {
+        simple_edg![
+            A => -> {B, C} -> {D};
+            B => ;
+            C => .> D;
+            D => -> {};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, false);
+        edg_assert!(C, false);
+        edg_assert!(D, true);
+    }
 
-        *self.assignment().get(&self.v0).unwrap()
+    #[test]
+    fn test_global_algorithm_general_02() {
+        simple_edg![
+            A => -> {B, C};
+            B => .> E;
+            C => -> {};
+            D => -> {} -> {C};
+            E => .> D;
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, true);
+        edg_assert!(C, true);
+        edg_assert!(D, true);
+        edg_assert!(E, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_03() {
+        simple_edg![
+            A => -> {B} -> {E};
+            B => -> {C};
+            C => -> {F} -> {H};
+            D => -> {E} -> {C};
+            E => -> {D, F};
+            F => -> {};
+            G => .> A;
+            H => -> {I};
+            I => ;
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, true);
+        edg_assert!(C, true);
+        edg_assert!(D, true);
+        edg_assert!(E, true);
+        edg_assert!(F, true);
+        edg_assert!(G, false);
+        edg_assert!(H, false);
+        edg_assert!(I, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_04() {
+        simple_edg![
+            A => -> {B} -> {C};
+            B => -> {D};
+            C => ;
+            D => -> {};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, true);
+        edg_assert!(C, false);
+        edg_assert!(D, true);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_05() {
+        simple_edg![
+            A => -> {B};
+            B => -> {C};
+            C => -> {B};
+        ];
+        edg_assert!(A, false);
+        edg_assert!(B, false);
+        edg_assert!(C, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_06() {
+        simple_edg![
+            A => -> {B} -> {C};
+            B => ;
+            C => ;
+        ];
+        edg_assert!(A, false);
+        edg_assert!(B, false);
+        edg_assert!(C, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_07() {
+        simple_edg![
+            A => -> {B};
+            B => -> {A, C};
+            C => -> {D};
+            D => -> {};
+        ];
+        edg_assert!(A, false);
+        edg_assert!(B, false);
+        edg_assert!(C, true);
+        edg_assert!(D, true);
+    }
+
+    #[test]
+    fn test_global_algorithm_general_08() {
+        simple_edg![
+            A => -> {B, C};
+            B => -> {C} -> {D};
+            C => -> {B};
+            D => -> {C} -> {};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, true);
+        edg_assert!(C, true);
+        edg_assert!(D, true);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_01() {
+        simple_edg![
+            A => .> B;
+            B => -> {};
+        ];
+        edg_assert!(A, false);
+        edg_assert!(B, true);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_02() {
+        simple_edg![
+            A => .> B;
+            B => -> {C};
+            C => -> {B} .> D;
+            D => -> {E};
+            E => -> {D};
+        ];
+        edg_assert!(A, false);
+        edg_assert!(B, true);
+        edg_assert!(C, true);
+        edg_assert!(D, false);
+        edg_assert!(E, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_03() {
+        simple_edg![
+            A => .> B .> C;
+            B => .> D;
+            C => -> {D};
+            D => ;
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, true);
+        edg_assert!(C, false);
+        edg_assert!(D, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_04() {
+        simple_edg![
+            A => .> B;
+            B => -> {B};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_05() {
+        simple_edg![
+            A => .> B;
+            B => .> C;
+            C => .> D;
+            D => .> E;
+            E => .> F;
+            F => -> {F};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, false);
+        edg_assert!(C, true);
+        edg_assert!(D, false);
+        edg_assert!(E, true);
+        edg_assert!(F, false);
+    }
+
+    #[test]
+    fn test_global_algorithm_negation_to_undecided_01() {
+        // A case where we might explore and find a negation edges to something that is
+        // currently assigned undecided
+        simple_edg![
+            A => .> B .> E;
+            B => -> {C};
+            C => -> {D};
+            D => .> E;
+            E => -> {F};
+            F => -> {G};
+            G => -> {H};
+            H => -> {I};
+            I => -> {J};
+            J => -> {K};
+            K => -> {};
+        ];
+        edg_assert!(A, true);
+        edg_assert!(B, false);
+        edg_assert!(C, false);
+        edg_assert!(D, false);
+        edg_assert!(E, true);
+        edg_assert!(F, true);
+        edg_assert!(G, true);
     }
 }

--- a/atl-checker/src/algorithms/global/singlethread.rs
+++ b/atl-checker/src/algorithms/global/singlethread.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::Debug;
 use crate::algorithms::global::GlobalAlgorithm;
 use crate::edg::{ExtendedDependencyGraph, Vertex};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::Debug;
 // Based on the global algorithm described in "Extended Dependency Graphs and Efficient Distributed Fixed-Point Computation" by A.E. Dalsgaard et al., 2017
 pub struct SinglethreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Vertex> {
     edg: G,
@@ -13,7 +13,11 @@ pub struct SinglethreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Verte
     dist: VecDeque<HashSet<V>>,
 }
 
-impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> GlobalAlgorithm<G,V> for SinglethreadedGlobalAlgorithm<G,V> {
+impl<
+        G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static,
+        V: Vertex + Send + Sync + 'static,
+    > GlobalAlgorithm<G, V> for SinglethreadedGlobalAlgorithm<G, V>
+{
     fn edg(&self) -> &G {
         &self.edg
     }
@@ -40,11 +44,15 @@ impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: V
     }
 }
 
-impl<G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static, V: Vertex + Send + Sync + 'static> SinglethreadedGlobalAlgorithm<G,V>{
-    pub fn run(mut self)->bool{
-        GlobalAlgorithm::<G,V>::run(&mut self)
+impl<
+        G: ExtendedDependencyGraph<V> + Send + Sync + Clone + Debug + 'static,
+        V: Vertex + Send + Sync + 'static,
+    > SinglethreadedGlobalAlgorithm<G, V>
+{
+    pub fn run(mut self) -> bool {
+        GlobalAlgorithm::<G, V>::run(&mut self)
     }
-    pub fn new(edg: G,v0: V) -> Self {
+    pub fn new(edg: G, v0: V) -> Self {
         Self {
             edg,
             v0,

--- a/atl-checker/src/algorithms/global/singlethread.rs
+++ b/atl-checker/src/algorithms/global/singlethread.rs
@@ -10,7 +10,7 @@ pub struct SinglethreadedGlobalAlgorithm<G: ExtendedDependencyGraph<V>, V: Verte
     /// The assignment for all vertices, we use this to keep track  of the current assignment
     assignment: HashMap<V, bool>,
     /// The distance of a vertex is represented as the index number of which set the vertex is located in
-    dist: VecDeque<HashSet<V>>,
+    component: VecDeque<HashSet<V>>,
 }
 
 impl<
@@ -36,11 +36,11 @@ impl<
     fn assignment_mut(&mut self) -> &mut HashMap<V, bool> {
         &mut self.assignment
     }
-    fn dist(&self) -> &VecDeque<HashSet<V>> {
-        &self.dist
+    fn components(&self) -> &VecDeque<HashSet<V>> {
+        &self.component
     }
-    fn dist_mut(&mut self) -> &mut VecDeque<HashSet<V>> {
-        &mut self.dist
+    fn components_mut(&mut self) -> &mut VecDeque<HashSet<V>> {
+        &mut self.component
     }
 }
 
@@ -57,7 +57,7 @@ impl<
             edg,
             v0,
             assignment: HashMap::<V, bool>::new(),
-            dist: VecDeque::<HashSet<V>>::new(),
+            component: VecDeque::<HashSet<V>>::new(),
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -207,6 +207,11 @@ fn main_inner() -> Result<(), String> {
             let model_and_formula = load(model_type, input_model_path, formula_path, formula_type)?;
             let quiet = global_args.is_present("quiet");
 
+            let threads = match solver_args.value_of("threads") {
+                None => num_cpus::get() as u64,
+                Some(t_arg) => t_arg.parse().unwrap(),
+            };
+
             let result = match model_and_formula {
                 ModelAndFormula::Lcgs { model, formula } => {
                     if !quiet {
@@ -219,7 +224,7 @@ fn main_inner() -> Result<(), String> {
                     let graph = AtlDependencyGraph {
                         game_structure: model,
                     };
-                    GlobalAlgorithm::new(graph, v0).run()
+                    GlobalAlgorithm::new(graph, threads,v0).run()
                 }
                 ModelAndFormula::Json { model, formula } => {
                     println!("Checking the formula: {}", formula.in_context_of(&model));
@@ -230,7 +235,7 @@ fn main_inner() -> Result<(), String> {
                     let graph = AtlDependencyGraph {
                         game_structure: model,
                     };
-                    GlobalAlgorithm::new(graph, v0).run()
+                    GlobalAlgorithm::new(graph, threads, v0).run()
                 }
             };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -228,7 +228,10 @@ fn main_inner() -> Result<(), String> {
                     };
 
                     if threads > 1 {
-                        MultithreadedGlobalAlgorithm::new(graph, threads, v0).run()
+                        // The numbers of worker is one less than threads
+                        // since the master is running in its own thread.
+                        let worker_count = threads-1;
+                        MultithreadedGlobalAlgorithm::new(graph, worker_count, v0).run()
                     } else if threads == 1 {
                         SinglethreadedGlobalAlgorithm::new(graph, v0).run()
                     } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,14 +20,14 @@ use atl_checker::algorithms::global::multithread::MultithreadedGlobalAlgorithm;
 use atl_checker::algorithms::global::singlethread::SinglethreadedGlobalAlgorithm;
 use atl_checker::analyse::analyse;
 use atl_checker::atl::{AtlExpressionParser, Phi};
-use atl_checker::edg::atledg::AtlDependencyGraph;
 use atl_checker::edg::atledg::vertex::AtlVertex;
+use atl_checker::edg::atledg::AtlDependencyGraph;
 use atl_checker::edg::ExtendedDependencyGraph;
-use atl_checker::game_structure::{EagerGameStructure, GameStructure};
 use atl_checker::game_structure::lcgs::ast::DeclKind;
 use atl_checker::game_structure::lcgs::ir::intermediate::IntermediateLcgs;
 use atl_checker::game_structure::lcgs::ir::symbol_table::Owner;
 use atl_checker::game_structure::lcgs::parse::parse_lcgs;
+use atl_checker::game_structure::{EagerGameStructure, GameStructure};
 #[cfg(feature = "graph-printer")]
 use atl_checker::printer::print_graph;
 
@@ -228,7 +228,7 @@ fn main_inner() -> Result<(), String> {
                     };
 
                     if threads > 1 {
-                        MultithreadedGlobalAlgorithm::new(graph, threads,v0).run()
+                        MultithreadedGlobalAlgorithm::new(graph, threads, v0).run()
                     } else if threads == 1 {
                         SinglethreadedGlobalAlgorithm::new(graph, v0).run()
                     } else {
@@ -247,7 +247,7 @@ fn main_inner() -> Result<(), String> {
                     };
 
                     if threads > 1 {
-                        MultithreadedGlobalAlgorithm::new(graph, threads,v0).run()
+                        MultithreadedGlobalAlgorithm::new(graph, threads, v0).run()
                     } else if threads == 1 {
                         SinglethreadedGlobalAlgorithm::new(graph, v0).run()
                     } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -230,13 +230,12 @@ fn main_inner() -> Result<(), String> {
                     if threads > 1 {
                         // The numbers of worker is one less than threads
                         // since the master is running in its own thread.
-                        let worker_count = threads-1;
+                        let worker_count = threads - 1;
                         MultithreadedGlobalAlgorithm::new(graph, worker_count, v0).run()
                     } else if threads == 1 {
                         SinglethreadedGlobalAlgorithm::new(graph, v0).run()
                     } else {
-                        println!("The number of threads have to be positive");
-                        panic!("The number of threads have to be positive")
+                        Err("The number must be a positive integer")?
                     }
                 }
                 ModelAndFormula::Json { model, formula } => {
@@ -254,8 +253,7 @@ fn main_inner() -> Result<(), String> {
                     } else if threads == 1 {
                         SinglethreadedGlobalAlgorithm::new(graph, v0).run()
                     } else {
-                        println!("The number of threads have to be positive");
-                        panic!("The number of threads have to be positive")
+                        Err("The number must be a positive integer")?
                     }
                 }
             };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@
 extern crate git_version;
 extern crate num_cpus;
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -227,15 +228,15 @@ fn main_inner() -> Result<(), String> {
                         game_structure: model,
                     };
 
-                    if threads > 1 {
-                        // The numbers of worker is one less than threads
-                        // since the master is running in its own thread.
-                        let worker_count = threads - 1;
-                        MultithreadedGlobalAlgorithm::new(graph, worker_count, v0).run()
-                    } else if threads == 1 {
-                        SinglethreadedGlobalAlgorithm::new(graph, v0).run()
-                    } else {
-                        Err("The number must be a positive integer")?
+                    match threads.cmp(&1) {
+                        Ordering::Less => Err("The number must be a positive integer")?,
+                        Ordering::Equal => SinglethreadedGlobalAlgorithm::new(graph, v0).run(),
+                        Ordering::Greater => {
+                            // The numbers of worker is one less than threads
+                            // since the master is running in its own thread.
+                            let worker_count = threads - 1;
+                            MultithreadedGlobalAlgorithm::new(graph, worker_count, v0).run()
+                        }
                     }
                 }
                 ModelAndFormula::Json { model, formula } => {
@@ -248,12 +249,15 @@ fn main_inner() -> Result<(), String> {
                         game_structure: model,
                     };
 
-                    if threads > 1 {
-                        MultithreadedGlobalAlgorithm::new(graph, threads, v0).run()
-                    } else if threads == 1 {
-                        SinglethreadedGlobalAlgorithm::new(graph, v0).run()
-                    } else {
-                        Err("The number must be a positive integer")?
+                    match threads.cmp(&1) {
+                        Ordering::Less => Err("The number must be a positive integer")?,
+                        Ordering::Equal => SinglethreadedGlobalAlgorithm::new(graph, v0).run(),
+                        Ordering::Greater => {
+                            // The numbers of worker is one less than threads
+                            // since the master is running in its own thread.
+                            let worker_count = threads - 1;
+                            MultithreadedGlobalAlgorithm::new(graph, worker_count, v0).run()
+                        }
                     }
                 }
             };


### PR DESCRIPTION
I have implemented at simple solution for a multithreaded global algorithm. The idea is to have an producer-consumer setup, where the workers exhaust a queue while the master populate it with tasks.  Here is the overview:

As the single threaded version the whole EDG is explore beforehand and splitted up in components relative to the initial vertex, v0, by the master.

Then the master spawns n workers and starts populating the work-queue with the vertices of the current component. When a worker have calculated the value of a vertice it sends it back to the master - which updates its assignments and note if the updates is a change. The master requeues all the vertices in the component if there have been changes. 

When the queue is empy, all vertices in the current component have been processed and nothing have changed since last run. The vertices of the next combonent is queued, and the process is repeated.

When all components have been processed and nothing changes, all the workers is terminated and the master returns with the value of v0.