### PR TITLE
Add Linear Representative search strategy

### DIFF
--- a/atl-checker/src/algorithms/certain_zero/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/mod.rs
@@ -51,7 +51,7 @@ pub fn distributed_certain_zero<
             v0.clone(),
             brokers.pop().unwrap(),
             edg.clone(),
-            ss_builder.build(),
+            ss_builder.build(&v0),
             prioritise_back_propagation,
         );
         thread::spawn(move || {

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/bfs.rs
@@ -39,7 +39,7 @@ impl<V: Vertex> SearchStrategy<V> for BreadthFirstSearch<V> {
 pub struct BreadthFirstSearchBuilder;
 
 impl<V: Vertex> SearchStrategyBuilder<V, BreadthFirstSearch<V>> for BreadthFirstSearchBuilder {
-    fn build(&self) -> BreadthFirstSearch<V> {
+    fn build(&self, _root: &V) -> BreadthFirstSearch<V> {
         BreadthFirstSearch::new()
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dependency_heuristic.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dependency_heuristic.rs
@@ -121,7 +121,7 @@ pub struct DependencyHeuristicSearchBuilder;
 impl<V: Vertex> SearchStrategyBuilder<V, DependencyHeuristicSearch<V>>
     for DependencyHeuristicSearchBuilder
 {
-    fn build(&self) -> DependencyHeuristicSearch<V> {
+    fn build(&self, _root: &V) -> DependencyHeuristicSearch<V> {
         DependencyHeuristicSearch::new()
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/dfs.rs
@@ -34,7 +34,7 @@ impl<V: Vertex> SearchStrategy<V> for DepthFirstSearch<V> {
 pub struct DepthFirstSearchBuilder;
 
 impl<V: Vertex> SearchStrategyBuilder<V, DepthFirstSearch<V>> for DepthFirstSearchBuilder {
-    fn build(&self) -> DepthFirstSearch<V> {
+    fn build(&self, _root: &V) -> DepthFirstSearch<V> {
         DepthFirstSearch::new()
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/instability_heuristic_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/instability_heuristic_search.rs
@@ -149,7 +149,7 @@ pub struct InstabilityHeuristicSearchBuilder {
 impl SearchStrategyBuilder<AtlVertex, InstabilityHeuristicSearch>
     for InstabilityHeuristicSearchBuilder
 {
-    fn build(&self) -> InstabilityHeuristicSearch {
+    fn build(&self, _root: &AtlVertex) -> InstabilityHeuristicSearch {
         InstabilityHeuristicSearch::new(self.game.clone())
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_optimize.rs
@@ -21,7 +21,7 @@ pub struct LinearOptimizeSearchBuilder {
 }
 
 impl SearchStrategyBuilder<AtlVertex, LinearOptimizeSearch> for LinearOptimizeSearchBuilder {
-    fn build(&self) -> LinearOptimizeSearch {
+    fn build(&self, _root: &AtlVertex) -> LinearOptimizeSearch {
         LinearOptimizeSearch::new(self.game.clone())
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -1,9 +1,7 @@
 use crate::algorithms::certain_zero::search_strategy::linear_constrained_phi::{
-    ConstrainedPhiMaker, LinearConstrainedPhi,
+    all_variants, ConstrainedPhiMaker, LinearConstrainedPhi,
 };
-use crate::algorithms::certain_zero::search_strategy::linear_constraints::{
-    ComparisonOp, LinearConstraint,
-};
+use crate::algorithms::certain_zero::search_strategy::linear_constraints::ComparisonOp;
 use crate::algorithms::certain_zero::search_strategy::{SearchStrategy, SearchStrategyBuilder};
 use crate::atl::Phi;
 use crate::edg::atledg::vertex::AtlVertex;
@@ -199,46 +197,5 @@ impl LinearProgrammingSearch {
         }
 
         best
-    }
-}
-
-/// Returns all variants of linear problems that can be created from the given LinearConstrainedPhi.
-/// Each problem consists of a list of linear constraints.
-fn all_variants(phi: &LinearConstrainedPhi) -> Vec<Vec<LinearConstraint>> {
-    all_variants_rec(vec![vec![]], phi)
-}
-/// Recursive helper function to [all_variants].
-fn all_variants_rec(
-    mut variants: Vec<Vec<LinearConstraint>>,
-    phi: &LinearConstrainedPhi,
-) -> Vec<Vec<LinearConstraint>> {
-    match phi {
-        LinearConstrainedPhi::Or(lhs, rhs) => {
-            // Clone of the variants found so far. Recurse into the LHS with original variants and
-            // recurse into the RHS with the cloned variants. Then union the results of both branches.
-            let clone = variants.clone();
-            let mut res = all_variants_rec(variants, lhs);
-            res.extend(all_variants_rec(clone, rhs));
-            res
-        }
-        LinearConstrainedPhi::And(lhs, rhs) => {
-            // Recurse into the LHS. Use the resulting variants to recurse into the RHS.
-            variants = all_variants_rec(variants, lhs);
-            variants = all_variants_rec(variants, rhs);
-            variants
-        }
-        LinearConstrainedPhi::Constraint(constraint) => {
-            // Add this constraint to all variants found so far
-            for variant in variants.iter_mut() {
-                variant.push(constraint.clone());
-            }
-            variants
-        }
-        // No variants of this branch will ever be true, so we throw them all away
-        LinearConstrainedPhi::False => vec![],
-        // No changes to variants
-        LinearConstrainedPhi::True => variants,
-        // No changes to variants
-        LinearConstrainedPhi::NonLinear => variants,
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -22,7 +22,7 @@ pub struct LinearProgrammingSearchBuilder {
 }
 
 impl SearchStrategyBuilder<AtlVertex, LinearProgrammingSearch> for LinearProgrammingSearchBuilder {
-    fn build(&self) -> LinearProgrammingSearch {
+    fn build(&self, _root: &AtlVertex) -> LinearProgrammingSearch {
         LinearProgrammingSearch::new(self.game.clone())
     }
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/linear_representative_search.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/linear_representative_search.rs
@@ -1,0 +1,115 @@
+use crate::algorithms::certain_zero::search_strategy::linear_constrained_phi::{
+    all_variants, ConstrainedPhiMaker,
+};
+use crate::algorithms::certain_zero::search_strategy::linear_constraints::ComparisonOp;
+use crate::algorithms::certain_zero::search_strategy::SearchStrategy;
+use crate::atl::Phi;
+use crate::edg::atledg::vertex::AtlVertex;
+use crate::edg::Edge;
+use crate::game_structure::lcgs::ast::DeclKind;
+use crate::game_structure::lcgs::ir::intermediate::{IntermediateLcgs, State};
+use minilp::{LinearExpr, OptimizationDirection, Problem};
+use priority_queue::PriorityQueue;
+use std::collections::HashMap;
+
+/// The [LinearRepresentativeSearch] is a search strategy that uses linear programming and
+/// the LCGS's representation of states in order to prioritize the edges during the search.
+/// However, it will only solve the linear programming problem once for the root formula,
+/// and use the solution states as a representatives for the feasible regions of the formula.
+/// Edges are then prioritized based on their manhattan distance to the representative states.
+struct LinearRepresentativeSearch {
+    game: IntermediateLcgs,
+    queue: PriorityQueue<Edge<AtlVertex>, u32>,
+    representatives: Vec<State>,
+}
+
+impl LinearRepresentativeSearch {
+    fn new(game: IntermediateLcgs, representatives: Vec<State>) -> LinearRepresentativeSearch {
+        LinearRepresentativeSearch {
+            game,
+            queue: PriorityQueue::new(),
+            representatives,
+        }
+    }
+
+    /// Find and use the representative states for the feasible regions of phi.
+    fn set_representatives(&mut self, phi: &Phi) {
+        self.representatives.clear();
+        let linear_phi = ConstrainedPhiMaker::new().convert(&self.game, phi);
+        for constraints in all_variants(&linear_phi) {
+            let mut problem = Problem::new(OptimizationDirection::Minimize);
+
+            // Add variable for each state variable
+            let mut vars = HashMap::new();
+            for state_var in self.game.get_vars() {
+                let decl = self.game.get_decl(&state_var).unwrap();
+                let DeclKind::StateVar(var_decl) = &decl.kind else { unreachable!() };
+                let range = (
+                    *var_decl.ir_range.start() as f64,
+                    *var_decl.ir_range.end() as f64,
+                );
+                let var = problem.add_var(1.0, range);
+                vars.insert(state_var, var);
+            }
+
+            // Add constraints based on phi
+            for constraint in &constraints {
+                if constraint.comparison == ComparisonOp::NotEqual {
+                    // We skip not-equal constraints since the minilp cannot handle them.
+                    // They don't restrict the solution space in a meaningful way anyway.
+                    continue;
+                }
+
+                let mut lin_expr = LinearExpr::empty();
+                for (state_var, coefficient) in &constraint.terms {
+                    let goal_var = vars.get(state_var).unwrap();
+                    lin_expr.add(*goal_var, *coefficient);
+                }
+                problem.add_constraint(
+                    lin_expr,
+                    constraint.comparison.into(),
+                    -constraint.constant,
+                );
+            }
+
+            // Extract solution
+            if let Ok(solution) = problem.solve() {
+                let mut state = State(HashMap::new());
+                for (state_var, goal_var) in vars {
+                    let v = solution[goal_var] as i32;
+                    state.0.insert(state_var, v);
+                }
+                self.representatives.push(state);
+            }
+        }
+    }
+
+    /// Returns the distance between the given state and the closest representative state
+    fn dist_to_representative(&self, state: &State) -> u32 {
+        self.representatives
+            .iter()
+            .map(|rep| {
+                let mut dist = 0;
+                for state_var in self.game.get_vars() {
+                    dist += (state.0[&state_var] - rep.0[&state_var]).unsigned_abs();
+                }
+                dist
+            })
+            .min()
+            .unwrap_or(0) // If there are no representatives, then phi may not be satisfiable anyway
+    }
+}
+
+impl SearchStrategy<AtlVertex> for LinearRepresentativeSearch {
+    fn next(&mut self) -> Option<Edge<AtlVertex>> {
+        self.queue.pop().map(|entry| entry.0)
+    }
+
+    fn queue_new_edges(&mut self, edges: Vec<Edge<AtlVertex>>) {
+        for edge in edges {
+            let state = self.game.state_from_index(edge.source().state());
+            let dist = self.dist_to_representative(&state);
+            self.queue.push(edge, u32::MAX - dist);
+        }
+    }
+}

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -46,5 +46,5 @@ pub trait SearchStrategy<V: Vertex> {
 /// This trait allows us to create a SearchStrategy instance for each worker in the certain zero
 /// algorithm, based on the settings given by the user.
 pub trait SearchStrategyBuilder<V: Vertex, S: SearchStrategy<V>> {
-    fn build(&self) -> S;
+    fn build(&self, root: &V) -> S;
 }

--- a/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/atl-checker/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -8,6 +8,7 @@ mod linear_constrained_phi;
 mod linear_constraints;
 pub mod linear_optimize;
 pub mod linear_programming_search;
+pub mod linear_representative_search;
 
 /// A SearchStrategy defines in which order safe edges of an EDG is processed first in the
 /// certain zero algorithm.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,6 +66,7 @@ pub enum SearchStrategyOption {
     Dfs,
     Dhs,
     Ihs,
+    Lrs,
 }
 
 impl SearchStrategyOption {
@@ -79,7 +80,10 @@ impl SearchStrategyOption {
         find_game_strategy: bool,
     ) -> ModelCheckResult {
         match self {
-            SearchStrategyOption::Los | SearchStrategyOption::Lps | SearchStrategyOption::Ihs => {
+            SearchStrategyOption::Los
+            | SearchStrategyOption::Lps
+            | SearchStrategyOption::Ihs
+            | SearchStrategyOption::Lrs => {
                 panic!("Cannot do generic model check with {:?}", self)
             }
             SearchStrategyOption::Bfs => model_check(
@@ -461,7 +465,8 @@ fn get_search_strategy_from_args(args: &ArgMatches) -> Result<SearchStrategyOpti
         Some("los") => Ok(SearchStrategyOption::Los),
         Some("lps") => Ok(SearchStrategyOption::Lps),
         Some("ihs") => Ok(SearchStrategyOption::Ihs),
-        Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies are \"bfs\", \"dfs\", \"los\", \"dhs\", \"ihs\"  [default is \"bfs\"]", other)),
+        Some("lrs") => Ok(SearchStrategyOption::Lrs),
+        Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies are bfs, dfs, lps, los, dhs, ihs, lrs  [default is 'bfs']", other)),
         // Default value
         None => Ok(SearchStrategyOption::Bfs)
     }

--- a/cli/src/solver.rs
+++ b/cli/src/solver.rs
@@ -5,6 +5,7 @@ use atl_checker::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearc
 use atl_checker::algorithms::certain_zero::search_strategy::instability_heuristic_search::InstabilityHeuristicSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::linear_optimize::LinearOptimizeSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::linear_programming_search::LinearProgrammingSearchBuilder;
+use atl_checker::algorithms::certain_zero::search_strategy::linear_representative_search::LinearRepresentativeSearchBuilder;
 use atl_checker::algorithms::certain_zero::search_strategy::{
     SearchStrategy, SearchStrategyBuilder,
 };
@@ -36,6 +37,9 @@ pub fn solver(
         }
         (ModelAndFormula::Json { .. }, SearchStrategyOption::Ihs) => {
             Err("Instability heuristic search is not supported for JSON models".to_string())
+        }
+        (ModelAndFormula::Json { .. }, SearchStrategyOption::Lrs) => {
+            Err("Linear representative search is not supported for JSON models".to_string())
         }
         (ModelAndFormula::Json { model, formula }, ss) => {
             let v0 = AtlVertex::Full {
@@ -143,6 +147,18 @@ pub fn solver(
                         v0,
                         threads,
                         InstabilityHeuristicSearchBuilder { game: copy },
+                        prioritise_back_propagation,
+                        game_strategy_path,
+                        quiet,
+                    )
+                }
+                SearchStrategyOption::Lrs => {
+                    let copy = graph.game_structure.clone();
+                    solver_inner(
+                        graph,
+                        v0,
+                        threads,
+                        LinearRepresentativeSearchBuilder::new(copy),
                         prioritise_back_propagation,
                         game_strategy_path,
                         quiet,


### PR DESCRIPTION
A search strategy suggested by Mathias CJ.

The LinearRepresentativeSearch is a search strategy that uses linear programming and the LCGS's representation of states in order to prioritize the edges during the search. However, it will only solve the linear programming problem once for the root formula, and use the solution states as representatives for the feasible regions of the formula. Edges are then prioritized based on their Manhattan distance to the representative states.

Pressumably, this works well for reachability queries in models where similar states are structurally close, but it will have a much smaller overhead than the LPS search.