### PR TITLE
Fix CI failing to compile parser and remove lazy_static dependency

### DIFF
--- a/atl-checker/Cargo.toml
+++ b/atl-checker/Cargo.toml
@@ -33,7 +33,6 @@ crossbeam-channel = "0.5.0"
 pom = "3.2.0"
 serde = { version = "1.0.143", features = ["derive", "rc"] }
 tracing = "0.1"
-lazy_static = "1.4.0"
 joinery = "2.1.0"
 minilp = "0.2.2"
 priority-queue = "1.2.3"

--- a/atl-checker/src/game_structure/lcgs/parse.rs
+++ b/atl-checker/src/game_structure/lcgs/parse.rs
@@ -1,8 +1,5 @@
-extern crate lazy_static;
 extern crate pom;
 
-use std::borrow::Borrow;
-use std::collections::HashSet;
 use std::iter::Peekable;
 use std::str::{self, FromStr};
 use std::vec::Drain;
@@ -18,26 +15,20 @@ use crate::game_structure::lcgs::ast::*;
 use crate::game_structure::lcgs::precedence::Associativity::RightToLeft;
 use crate::game_structure::lcgs::precedence::{precedence, Precedence};
 
-use self::pom::set::Set;
 use self::pom::Error;
 
-// Required for static allocation of a hashset
-lazy_static! {
-    static ref RESERVED_KEYWORDS: HashSet<&'static str> = {
-        let mut set = HashSet::new();
-        set.insert("const");
-        set.insert("label");
-        set.insert("player");
-        set.insert("template");
-        set.insert("endtemplate");
-        set.insert("init");
-        set.insert("true");
-        set.insert("false");
-        set.insert("min");
-        set.insert("max");
-        set
-    };
-}
+const RESERVED_KEYWORDS: [&str; 10] = [
+    "const",
+    "label",
+    "player",
+    "template",
+    "endtemplate",
+    "init",
+    "true",
+    "false",
+    "min",
+    "max",
+];
 
 /// A `Span` describes the position of a slice of text in the original program.
 /// Usually used to describe what text an AST node was created from.
@@ -122,7 +113,7 @@ fn name<'a>() -> Parser<'a, u8, String> {
         .collect()
         .convert(|s| String::from_utf8(s.to_vec()))
         .convert(|name| {
-            if RESERVED_KEYWORDS.contains(name.to_str().borrow()) {
+            if RESERVED_KEYWORDS.contains(&name.as_str()) {
                 Err(format!(
                     "Cannot use a reserved keyword as an identifier: {}",
                     name

--- a/atl-checker/src/lib.rs
+++ b/atl-checker/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate tracing;
 
 #[macro_use]


### PR DESCRIPTION
The CI suddenly started to refuse compiling the parser. It can no longer infer the type of our list of reserved keywords. See https://github.com/d702e20/CGAAL/actions/runs/5308631315/jobs/9608318973?pr=193#step:4:164

![image](https://github.com/d702e20/CGAAL/assets/21122471/5d45d3b3-ea93-4549-bc96-8783fbb7a084)

This PR fixes that and removes the `lazy_static` dependency.
