### PR TITLE
fmt main with new let-else rules

### DIFF
--- a/cgaal-engine/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
+++ b/cgaal-engine/src/algorithms/certain_zero/search_strategy/linear_programming_search.rs
@@ -131,7 +131,9 @@ impl LinearProgrammingSearch {
             let mut symbol_vars: HashMap<SymbolIdentifier, Variable> = HashMap::new();
             for state_var in self.game.get_vars() {
                 let decl = self.game.get_decl(&state_var).unwrap();
-                let DeclKind::StateVar(var_decl) = &decl.kind else { unreachable!() };
+                let DeclKind::StateVar(var_decl) = &decl.kind else {
+                    unreachable!()
+                };
                 let range = (
                     *var_decl.ir_range.start() as f64,
                     *var_decl.ir_range.end() as f64,

--- a/cgaal-engine/src/algorithms/certain_zero/search_strategy/linear_representative_search.rs
+++ b/cgaal-engine/src/algorithms/certain_zero/search_strategy/linear_representative_search.rs
@@ -38,7 +38,9 @@ impl LinearRepresentativeSearchBuilder {
             let mut vars = HashMap::new();
             for state_var in self.game.get_vars() {
                 let decl = self.game.get_decl(&state_var).unwrap();
-                let DeclKind::StateVar(var_decl) = &decl.kind else { unreachable!() };
+                let DeclKind::StateVar(var_decl) = &decl.kind else {
+                    unreachable!()
+                };
                 let range = (
                     *var_decl.ir_range.start() as f64,
                     *var_decl.ir_range.end() as f64,

--- a/cgaal-engine/src/edg/atledg/pmoves.rs
+++ b/cgaal-engine/src/edg/atledg/pmoves.rs
@@ -15,12 +15,16 @@ pub enum PartialMoveChoice {
 
 impl PartialMoveChoice {
     pub fn unwrap_range(&self) -> usize {
-        let PartialMoveChoice::Range(r) = self else { panic!("PartialMoveChoice was not a range of moves") };
+        let PartialMoveChoice::Range(r) = self else {
+            panic!("PartialMoveChoice was not a range of moves")
+        };
         *r
     }
 
     pub fn unwrap_specific(&self) -> usize {
-        let PartialMoveChoice::Specific(r) = self else { panic!("PartialMoveChoice was not a specific move") };
+        let PartialMoveChoice::Specific(r) = self else {
+            panic!("PartialMoveChoice was not a specific move")
+        };
         *r
     }
 }


### PR DESCRIPTION
Our main branch is not formatted correctly. The format rules for `let-else` statements have changed in the newer version of `rustfmt`.