### PR TITLE
Add composite search strategies

### DIFF
--- a/cgaal-cli/Cargo.toml
+++ b/cgaal-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cgaal"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
     "Asger Weirsøe <asger@weircon.dk>",
     "Falke Carlsen <falkeboc@cs.aau.dk>",
@@ -24,4 +24,4 @@ tracing-subscriber = "0.2.17"
 serde_json = "1.0.83"
 regex = { version = "1", features = ["unicode-case"] }
 humantime = "2.1.0"
-cgaal-engine = { path = "../cgaal-engine", version = "2.0.0" }
+cgaal-engine = { path = "../cgaal-engine", version = "2.0.1" }

--- a/cgaal-cli/src/args.rs
+++ b/cgaal-cli/src/args.rs
@@ -1,6 +1,7 @@
 use crate::options::{
     CliOptions, FormulaFormat, ModelFormat, SearchStrategyOption, SubcommandOption,
 };
+use cgaal_engine::algorithms::certain_zero::search_strategy::composite::CompositeSearchStrategyOption;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use git_version::git_version;
 
@@ -146,6 +147,18 @@ fn parse_search_strategy_arg(args: &ArgMatches) -> Result<SearchStrategyOption, 
         Some("lps") => Ok(SearchStrategyOption::Lps),
         Some("ihs") => Ok(SearchStrategyOption::Ihs),
         Some("lrs") => Ok(SearchStrategyOption::Lrs),
+        Some("mix") => Ok(SearchStrategyOption::Mix),
+        Some(multiple) if multiple.contains(",") => Ok(SearchStrategyOption::Compo(multiple.split(",").map(|ss| match ss {
+            "bfs" => Ok(CompositeSearchStrategyOption::Bfs),
+            "dfs" => Ok(CompositeSearchStrategyOption::Dfs),
+            "rdfs" => Ok(CompositeSearchStrategyOption::Rdfs),
+            "dhs" => Ok(CompositeSearchStrategyOption::Dhs),
+            "los" => Ok(CompositeSearchStrategyOption::Los),
+            "lps" => Ok(CompositeSearchStrategyOption::Lps),
+            "ihs" => Ok(CompositeSearchStrategyOption::Ihs),
+            "lrs" => Ok(CompositeSearchStrategyOption::Lrs),
+            other => Err(format!("Unknown search strategy '{other}' in composite strategy. Valid search strategies are bfs, dfs, rdfs, lps, los, dhs, ihs, lrs.")),
+        }).collect::<Result<_, _>>()?)),
         Some(other) => Err(format!("Unknown search strategy '{}'. Valid search strategies are bfs, dfs, rdfs, lps, los, dhs, ihs, lrs  [default is bfs]", other)),
         // Default value
         None => Ok(SearchStrategyOption::Bfs)
@@ -238,7 +251,8 @@ impl CommonArgs for App<'_, '_> {
             Arg::with_name("search_strategy")
                 .short("s")
                 .long("search-strategy")
-                .help("The search strategy used {{bfs, dfs, rdfs, los, lps, dhs, ihs, lrs}}"),
+                .takes_value(true)
+                .help("The search strategy used {{bfs, dfs, rdfs, los, lps, dhs, ihs, lrs, mix}}. Select multiple with comma separation."),
         )
         .arg(
             Arg::with_name("no_prioritised_back_propagation")

--- a/cgaal-cli/src/args.rs
+++ b/cgaal-cli/src/args.rs
@@ -148,7 +148,7 @@ fn parse_search_strategy_arg(args: &ArgMatches) -> Result<SearchStrategyOption, 
         Some("ihs") => Ok(SearchStrategyOption::Ihs),
         Some("lrs") => Ok(SearchStrategyOption::Lrs),
         Some("mix") => Ok(SearchStrategyOption::Mix),
-        Some(multiple) if multiple.contains(",") => Ok(SearchStrategyOption::Compo(multiple.split(",").map(|ss| match ss {
+        Some(multiple) if multiple.contains(',') => Ok(SearchStrategyOption::Compo(multiple.split(',').map(|ss| match ss {
             "bfs" => Ok(CompositeSearchStrategyOption::Bfs),
             "dfs" => Ok(CompositeSearchStrategyOption::Dfs),
             "rdfs" => Ok(CompositeSearchStrategyOption::Rdfs),

--- a/cgaal-cli/src/options.rs
+++ b/cgaal-cli/src/options.rs
@@ -1,3 +1,5 @@
+use cgaal_engine::algorithms::certain_zero::search_strategy::composite::CompositeSearchStrategyOption;
+
 /// The subcommands available
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum SubcommandOption {
@@ -24,7 +26,7 @@ pub enum ModelFormat {
 }
 
 /// Valid search strategies options
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub enum SearchStrategyOption {
     /// Breadth-first search
     #[default]
@@ -43,6 +45,10 @@ pub enum SearchStrategyOption {
     Dhs,
     /// Instability heuristic search
     Ihs,
+    /// Different search strategy for each worker
+    Mix,
+    /// Composite search strategy
+    Compo(Vec<CompositeSearchStrategyOption>),
 }
 
 /// The options that can be passed to the CLI

--- a/cgaal-cli/src/solver.rs
+++ b/cgaal-cli/src/solver.rs
@@ -1,6 +1,7 @@
 use crate::load::Model;
 use crate::options::{CliOptions, SearchStrategyOption};
 use cgaal_engine::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSearchBuilder;
+use cgaal_engine::algorithms::certain_zero::search_strategy::composite::CompositeSearchStrategyBuilder;
 use cgaal_engine::algorithms::certain_zero::search_strategy::dependency_heuristic::DependencyHeuristicSearchBuilder;
 use cgaal_engine::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearchBuilder;
 use cgaal_engine::algorithms::certain_zero::search_strategy::instability_heuristic_search::InstabilityHeuristicSearchBuilder;
@@ -175,6 +176,30 @@ pub fn solver(model: Model, formula: Phi, options: CliOptions) -> Result<(), Str
                         v0,
                         options.threads,
                         LinearRepresentativeSearchBuilder::new(copy),
+                        options.prioritise_back_propagation,
+                        options.witness_strategy_path.as_deref(),
+                        options.quiet,
+                    )
+                }
+                SearchStrategyOption::Mix => {
+                    let copy = graph.game_structure.clone();
+                    solver_inner(
+                        graph,
+                        v0,
+                        options.threads,
+                        CompositeSearchStrategyBuilder::one_of_each(copy),
+                        options.prioritise_back_propagation,
+                        options.witness_strategy_path.as_deref(),
+                        options.quiet,
+                    )
+                }
+                SearchStrategyOption::Compo(strategies) => {
+                    let copy = graph.game_structure.clone();
+                    solver_inner(
+                        graph,
+                        v0,
+                        options.threads,
+                        CompositeSearchStrategyBuilder::new(copy, strategies),
                         options.prioritise_back_propagation,
                         options.witness_strategy_path.as_deref(),
                         options.quiet,

--- a/cgaal-engine/Cargo.toml
+++ b/cgaal-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cgaal-engine"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
     "Asger Weirsøe <asger@weircon.dk>",
     "Falke Carlsen <falkeboc@cs.aau.dk>",

--- a/cgaal-engine/src/algorithms/certain_zero/search_strategy/composite.rs
+++ b/cgaal-engine/src/algorithms/certain_zero/search_strategy/composite.rs
@@ -93,7 +93,7 @@ impl CompositeSearchStrategyBuilder {
         strategies: Vec<CompositeSearchStrategyOption>,
     ) -> CompositeSearchStrategyBuilder {
         assert!(
-            strategies.len() > 0,
+            !strategies.is_empty(),
             "Composite search strategy must have at least one component search strategy"
         );
         CompositeSearchStrategyBuilder {
@@ -131,13 +131,16 @@ impl SearchStrategyBuilder<AtlVertex, CompositeSearchStrategyInstance>
         };
         let mut i = self.index.borrow_mut();
         *i = (*i + 1) % self.strategies.len();
-        return ss;
+        ss
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::algorithms::certain_zero::search_strategy::composite::{CompositeSearchStrategyBuilder, CompositeSearchStrategyInstance, CompositeSearchStrategyOption};
+    use crate::algorithms::certain_zero::search_strategy::composite::{
+        CompositeSearchStrategyBuilder, CompositeSearchStrategyInstance,
+        CompositeSearchStrategyOption,
+    };
     use crate::algorithms::certain_zero::search_strategy::SearchStrategyBuilder;
     use crate::atl::Phi;
     use crate::edg::atledg::vertex::AtlVertex;
@@ -152,22 +155,55 @@ mod test {
         let errors = ErrorLog::new();
         let lcgs = IntermediateLcgs::create(LcgsRoot::new(Span::empty(), vec![]), &errors).unwrap();
 
-        let builder = CompositeSearchStrategyBuilder::new(lcgs, vec![
-            CompositeSearchStrategyOption::Bfs,
-            CompositeSearchStrategyOption::Dfs,
-            CompositeSearchStrategyOption::Dhs,
-        ]);
+        let builder = CompositeSearchStrategyBuilder::new(
+            lcgs,
+            vec![
+                CompositeSearchStrategyOption::Bfs,
+                CompositeSearchStrategyOption::Dfs,
+                CompositeSearchStrategyOption::Dhs,
+            ],
+        );
 
-        let root = AtlVertex::Full { state: StateIdx(0), formula: Phi::True.into() };
+        let root = AtlVertex::Full {
+            state: StateIdx(0),
+            formula: Phi::True.into(),
+        };
 
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
-        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Bfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dhs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Bfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dhs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Bfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dfs(_)
+        ));
+        assert!(matches!(
+            builder.build(&root),
+            CompositeSearchStrategyInstance::Dhs(_)
+        ));
     }
 }

--- a/cgaal-engine/src/algorithms/certain_zero/search_strategy/composite.rs
+++ b/cgaal-engine/src/algorithms/certain_zero/search_strategy/composite.rs
@@ -1,0 +1,173 @@
+use crate::algorithms::certain_zero::search_strategy::bfs::BreadthFirstSearch;
+use crate::algorithms::certain_zero::search_strategy::dependency_heuristic::DependencyHeuristicSearch;
+use crate::algorithms::certain_zero::search_strategy::dfs::DepthFirstSearch;
+use crate::algorithms::certain_zero::search_strategy::instability_heuristic_search::InstabilityHeuristicSearch;
+use crate::algorithms::certain_zero::search_strategy::linear_optimize::LinearOptimizeSearch;
+use crate::algorithms::certain_zero::search_strategy::linear_programming_search::LinearProgrammingSearch;
+use crate::algorithms::certain_zero::search_strategy::linear_representative_search::{
+    LinearRepresentativeSearch, LinearRepresentativeSearchBuilder,
+};
+use crate::algorithms::certain_zero::search_strategy::rdfs::RandomDepthFirstSearch;
+use crate::algorithms::certain_zero::search_strategy::{SearchStrategy, SearchStrategyBuilder};
+use crate::edg::atledg::vertex::AtlVertex;
+use crate::edg::Edge;
+use crate::game_structure::lcgs::intermediate::IntermediateLcgs;
+use std::cell::RefCell;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum CompositeSearchStrategyOption {
+    /// Breadth-first search
+    Bfs,
+    /// Depth-first search
+    Dfs,
+    /// Random Depth-first search
+    Rdfs,
+    /// Linear optimization search
+    Los,
+    /// Linear programming search
+    Lps,
+    /// Linear representative search
+    Lrs,
+    /// Dependency heuristic search
+    Dhs,
+    /// Instability heuristic search
+    Ihs,
+}
+
+pub enum CompositeSearchStrategyInstance {
+    Bfs(BreadthFirstSearch<AtlVertex>),
+    Dfs(DepthFirstSearch<AtlVertex>),
+    Rdfs(RandomDepthFirstSearch<AtlVertex>),
+    Los(LinearOptimizeSearch),
+    Lps(LinearProgrammingSearch),
+    Lrs(LinearRepresentativeSearch),
+    Dhs(DependencyHeuristicSearch<AtlVertex>),
+    Ihs(InstabilityHeuristicSearch),
+}
+
+impl SearchStrategy<AtlVertex> for CompositeSearchStrategyInstance {
+    fn next(&mut self) -> Option<Edge<AtlVertex>> {
+        use CompositeSearchStrategyInstance as CssInst;
+        match self {
+            CssInst::Bfs(ss) => ss.next(),
+            CssInst::Dfs(ss) => ss.next(),
+            CssInst::Rdfs(ss) => ss.next(),
+            CssInst::Los(ss) => ss.next(),
+            CssInst::Lps(ss) => ss.next(),
+            CssInst::Lrs(ss) => ss.next(),
+            CssInst::Dhs(ss) => ss.next(),
+            CssInst::Ihs(ss) => ss.next(),
+        }
+    }
+
+    fn queue_new_edges(&mut self, edges: Vec<Edge<AtlVertex>>) {
+        use CompositeSearchStrategyInstance as CssInst;
+        match self {
+            CssInst::Bfs(ss) => ss.queue_new_edges(edges),
+            CssInst::Dfs(ss) => ss.queue_new_edges(edges),
+            CssInst::Rdfs(ss) => ss.queue_new_edges(edges),
+            CssInst::Los(ss) => ss.queue_new_edges(edges),
+            CssInst::Lps(ss) => ss.queue_new_edges(edges),
+            CssInst::Lrs(ss) => ss.queue_new_edges(edges),
+            CssInst::Dhs(ss) => ss.queue_new_edges(edges),
+            CssInst::Ihs(ss) => ss.queue_new_edges(edges),
+        }
+    }
+}
+
+/// The [CompositeSearchStrategyBuilder] sequentially produces search strategies from a vec of
+/// selected search strategies and thus makes it possible to use of different search
+/// strategies across different worker. A search strategy can be selected multiple times.
+///
+/// E.g. if the selected strategies are BFS, BFS, RDFS, then every third worker will use the
+/// RDFS strategy, while the remaining workers will use the BFS strategy.
+pub struct CompositeSearchStrategyBuilder {
+    pub game: IntermediateLcgs,
+    pub strategies: Vec<CompositeSearchStrategyOption>,
+    pub index: RefCell<usize>,
+}
+
+impl CompositeSearchStrategyBuilder {
+    pub fn new(
+        game: IntermediateLcgs,
+        strategies: Vec<CompositeSearchStrategyOption>,
+    ) -> CompositeSearchStrategyBuilder {
+        assert!(
+            strategies.len() > 0,
+            "Composite search strategy must have at least one component search strategy"
+        );
+        CompositeSearchStrategyBuilder {
+            game,
+            strategies,
+            index: RefCell::new(0),
+        }
+    }
+
+    /// Create a new [CompositeSearchStrategyBuilder] employing each search strategy evenly.
+    pub fn one_of_each(game: IntermediateLcgs) -> CompositeSearchStrategyBuilder {
+        use CompositeSearchStrategyOption::*;
+        // General/best strategies first in case the user is using few workers
+        Self::new(game, vec![Dhs, Rdfs, Ihs, Bfs, Lrs, Dfs, Los, Lps])
+    }
+}
+
+impl SearchStrategyBuilder<AtlVertex, CompositeSearchStrategyInstance>
+    for CompositeSearchStrategyBuilder
+{
+    fn build(&self, root: &AtlVertex) -> CompositeSearchStrategyInstance {
+        use CompositeSearchStrategyInstance as CssInst;
+        use CompositeSearchStrategyOption as CssOpt;
+        let ss = match self.strategies[*self.index.borrow()] {
+            CssOpt::Bfs => CssInst::Bfs(BreadthFirstSearch::new()),
+            CssOpt::Dfs => CssInst::Dfs(DepthFirstSearch::new()),
+            CssOpt::Rdfs => CssInst::Rdfs(RandomDepthFirstSearch::new()),
+            CssOpt::Los => CssInst::Los(LinearOptimizeSearch::new(self.game.clone())),
+            CssOpt::Lps => CssInst::Lps(LinearProgrammingSearch::new(self.game.clone())),
+            CssOpt::Lrs => {
+                CssInst::Lrs(LinearRepresentativeSearchBuilder::new(self.game.clone()).build(root))
+            }
+            CssOpt::Dhs => CssInst::Dhs(DependencyHeuristicSearch::new()),
+            CssOpt::Ihs => CssInst::Ihs(InstabilityHeuristicSearch::new(self.game.clone())),
+        };
+        let mut i = self.index.borrow_mut();
+        *i = (*i + 1) % self.strategies.len();
+        return ss;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::algorithms::certain_zero::search_strategy::composite::{CompositeSearchStrategyBuilder, CompositeSearchStrategyInstance, CompositeSearchStrategyOption};
+    use crate::algorithms::certain_zero::search_strategy::SearchStrategyBuilder;
+    use crate::atl::Phi;
+    use crate::edg::atledg::vertex::AtlVertex;
+    use crate::game_structure::lcgs::intermediate::IntermediateLcgs;
+    use crate::game_structure::StateIdx;
+    use crate::parsing::ast::LcgsRoot;
+    use crate::parsing::errors::ErrorLog;
+    use crate::parsing::span::Span;
+
+    #[test]
+    fn composite_search_strategy_001() {
+        let errors = ErrorLog::new();
+        let lcgs = IntermediateLcgs::create(LcgsRoot::new(Span::empty(), vec![]), &errors).unwrap();
+
+        let builder = CompositeSearchStrategyBuilder::new(lcgs, vec![
+            CompositeSearchStrategyOption::Bfs,
+            CompositeSearchStrategyOption::Dfs,
+            CompositeSearchStrategyOption::Dhs,
+        ]);
+
+        let root = AtlVertex::Full { state: StateIdx(0), formula: Phi::True.into() };
+
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Bfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dfs(_)));
+        assert!(matches!(builder.build(&root), CompositeSearchStrategyInstance::Dhs(_)));
+    }
+}

--- a/cgaal-engine/src/algorithms/certain_zero/search_strategy/mod.rs
+++ b/cgaal-engine/src/algorithms/certain_zero/search_strategy/mod.rs
@@ -1,6 +1,7 @@
 use crate::edg::{Edge, NegationEdge, Vertex};
 
 pub mod bfs;
+pub mod composite;
 pub mod dependency_heuristic;
 pub mod dfs;
 pub mod instability_heuristic_search;


### PR DESCRIPTION
Adds the feature described in #219. The search strategy `-s mix` makes each worker use a different search strategy. The composite search strategy `-s bfs,bfs,rdfs,ihs` makes worker 1, 2, 5, 6, 9, 10, etc use BFS; worker 3, 7, 11 etc uses RDFS; and worker 4, 8, 12, etc use IHS.

Also fixes a bug where the user could not select search strategy from the cli.

Benchmarking is TODO.